### PR TITLE
fixed ah search spelling

### DIFF
--- a/src/main/kotlin/features/inventory/ItemHotkeys.kt
+++ b/src/main/kotlin/features/inventory/ItemHotkeys.kt
@@ -29,7 +29,7 @@ object ItemHotkeys {
 		if (HypixelStaticData.hasBazaarStock(skyblockId)) {
 			MC.sendCommand("bz ${item.getSearchName()}")
 		} else if (HypixelStaticData.hasAuctionHouseOffers(skyblockId)) {
-			MC.sendCommand("ahs ${item.getSearchName()}")
+			MC.sendCommand("ahsearch ${item.getSearchName()}")
 		} else {
 			return
 		}


### PR DESCRIPTION
Since at least in my client and my coop's it wasnt working i changed to spelling of the command sent to teh game for auctionsearch:
The hotkey to open an ah of the hovered item sent the /ahs command instead of /ahsearch or /auctionsearch which at some point probably got deprecated