### PR TITLE
Update Fabric API dependency mod id

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -51,7 +51,7 @@
         "firmament.mixins.json"
     ],
     "depends": {
-        "fabric": ">=${fabric_api_version}",
+        "fabric-api": ">=${fabric_api_version}",
         "fabric-language-kotlin": ">=${fabric_kotlin_version}",
         "minecraft": ">=${minecraft_version}"
     },


### PR DESCRIPTION
Firmament uses the old Fabric API mod id and as a result if a user doesn't have the right version it will tell them to install `fabric` rather than `fabric-api` which could be confusing. I just edited this in place and it should probably be ok.