### PR TITLE
fix: prevent pet info hud from displaying outside of skyblock

### DIFF
--- a/src/main/kotlin/features/inventory/PetFeatures.kt
+++ b/src/main/kotlin/features/inventory/PetFeatures.kt
@@ -13,6 +13,7 @@ import moe.nea.firmament.gui.config.ManagedConfig
 import moe.nea.firmament.util.FirmFormatters.formatPercent
 import moe.nea.firmament.util.FirmFormatters.shortFormat
 import moe.nea.firmament.util.MC
+import moe.nea.firmament.util.SBData
 import moe.nea.firmament.util.petData
 import moe.nea.firmament.util.render.drawGuiTexture
 import moe.nea.firmament.util.skyblock.Rarity
@@ -52,7 +53,7 @@ object PetFeatures : FirmamentFeature {
 
 	@Subscribe
 	fun onRenderHud(it: HudRenderEvent) {
-		if (!TConfig.petOverlay) return
+		if (!TConfig.petOverlay || !SBData.isOnSkyblock) return
 		val itemStack = petItemStack ?: return
 		val petData = petItemStack?.petData ?: return
 		val rarity = Rarity.fromNeuRepo(petData.tier)


### PR DESCRIPTION
The pet info HUD currently displays when you aren't on SkyBlock. A bit of a nuisance when you are playing other games on Hypixel since it covers part of your screen. Hopefully, this PR stops this from happening.
I did a bit of testing with the change and it seems to disappear properly when going from SkyBlock to the Prototype lobby and doesn't disappear when moving between SkyBlock islands. I'm not sure if this affects it, but I haven't tested under high ping/a lot of lag.