### PR TITLE
change: timer in lore default

### DIFF
--- a/src/main/kotlin/features/inventory/TimerInLore.kt
+++ b/src/main/kotlin/features/inventory/TimerInLore.kt
@@ -22,7 +22,7 @@ import moe.nea.firmament.util.unformattedString
 
 object TimerInLore {
 	object TConfig : ManagedConfig("lore-timers", Category.INVENTORY) {
-		val showTimers by toggle("show") { true }
+		val showTimers by toggle("show") { false }
 		val showCreationTimestamp by toggle("show-creation") { true }
 		val timerFormat by choice("format") { TimerFormat.SOCIALIST }
 	}

--- a/translations/en_us.json
+++ b/translations/en_us.json
@@ -206,7 +206,7 @@
 	"firmament.config.jade-integration.progress.description": "Show the custom mining progress in Jade, when in a world with mining fatigue.",
 	"firmament.config.lore-timers": "Item Timestamps",
 	"firmament.config.lore-timers.format": "Time Format",
-	"firmament.config.lore-timers.format.choice.american": "§9Ame§cri§fcan",
+	"firmament.config.lore-timers.format.choice.american": "§9Free§cee§ftime",
 	"firmament.config.lore-timers.format.choice.local": "System Time Format",
 	"firmament.config.lore-timers.format.choice.rfc": "RFC",
 	"firmament.config.lore-timers.format.choice.rfcprecise": "RFC (Milliseconds)",


### PR DESCRIPTION
1. made the time less always showing and more only showing when wanted
2. made the wording for the American time format more clear what it was