### PR TITLE
fix: Item/NPC Exporter allows non alphabet or number chars in ID

### DIFF
--- a/src/main/kotlin/features/debug/itemeditor/ExportRecipe.kt
+++ b/src/main/kotlin/features/debug/itemeditor/ExportRecipe.kt
@@ -185,7 +185,7 @@ object ExportRecipe {
 	}
 
 	fun generateName(name: String): SkyblockId {
-		return SkyblockId(name.uppercase().replace(" ", "_").replace("(", "").replace(")", ""))
+		return SkyblockId(name.uppercase().replace(" ", "_").replace(Regex("[^A-Z_]+"), ""))
 	}
 
 	fun findStackableItemByName(name: String, fallbackToGenerated: Boolean = false): Pair<SkyblockId, Double>? {


### PR DESCRIPTION
untested
fixes #215 