### PR TITLE
fix: bazaar buy/sell order tooltip text swapped

### DIFF
--- a/src/main/kotlin/features/inventory/PriceData.kt
+++ b/src/main/kotlin/features/inventory/PriceData.kt
@@ -88,13 +88,13 @@ object PriceData : FirmamentFeature {
 			it.lines.add(multiplierText)
 			it.lines.add(
 				formatPrice(
-					tr("firmament.tooltip.bazaar.sell-order", "Bazaar Sell Order"),
+					tr("firmament.tooltip.bazaar.buy-order", "Bazaar Buy Order"),
 					bazaarData.quickStatus.sellPrice * multiplier
 				)
 			)
 			it.lines.add(
 				formatPrice(
-					tr("firmament.tooltip.bazaar.buy-order", "Bazaar Buy Order"),
+					tr("firmament.tooltip.bazaar.sell-order", "Bazaar Sell Order"),
 					bazaarData.quickStatus.buyPrice * multiplier
 				)
 			)


### PR DESCRIPTION

<img width="2064" height="167" alt="pr" src="https://github.com/user-attachments/assets/03a44a0d-6b4b-4334-9b74-9b3336368cd5" />

basic change, swapped the buy order and sell order text so that it actually makes sense.