### PR TITLE
Fix Instant crashes

### DIFF
--- a/src/main/kotlin/apis/Profiles.kt
+++ b/src/main/kotlin/apis/Profiles.kt
@@ -6,7 +6,7 @@ package moe.nea.firmament.apis
 
 import io.github.moulberry.repo.constants.Leveling
 import io.github.moulberry.repo.data.Rarity
-import kotlinx.datetime.Instant
+import java.time.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers

--- a/src/main/kotlin/util/json/InstantAsLongSerializer.kt
+++ b/src/main/kotlin/util/json/InstantAsLongSerializer.kt
@@ -2,7 +2,7 @@
 
 package moe.nea.firmament.util.json
 
-import kotlinx.datetime.Instant
+import java.time.Instant
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
@@ -13,10 +13,10 @@ import kotlinx.serialization.encoding.Encoder
 object InstantAsLongSerializer : KSerializer<Instant> {
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("InstantAsLongSerializer", PrimitiveKind.LONG)
     override fun deserialize(decoder: Decoder): Instant {
-        return Instant.fromEpochMilliseconds(decoder.decodeLong())
+        return Instant.ofEpochMilli(decoder.decodeLong())
     }
 
     override fun serialize(encoder: Encoder, value: Instant) {
-        encoder.encodeLong(value.toEpochMilliseconds())
+        encoder.encodeLong(value.toEpochMilli())
     }
 }

--- a/src/main/kotlin/util/mc/SkullItemData.kt
+++ b/src/main/kotlin/util/mc/SkullItemData.kt
@@ -5,9 +5,8 @@ package moe.nea.firmament.util.mc
 import com.mojang.authlib.GameProfile
 import com.mojang.authlib.minecraft.MinecraftProfileTexture
 import com.mojang.authlib.properties.Property
+import java.time.Instant
 import java.util.UUID
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import net.minecraft.component.DataComponentTypes
@@ -32,7 +31,7 @@ data class MinecraftTexturesPayloadKt(
     val profileId: UUID? = null,
     val profileName: String? = null,
     val isPublic: Boolean = true,
-    val timestamp: Instant = Clock.System.now(),
+    val timestamp: Instant = Instant.now(),
 )
 
 fun GameProfile.setTextures(textures: MinecraftTexturesPayloadKt) {


### PR DESCRIPTION
Uses Java's Instant instead since its more stable and other places (e.g. item timestamp parsing) seemed to use Java's time APIs as well.

Fixes #273 