### PR TITLE
feat: add Iris support to RenderPipelines

### DIFF
--- a/src/main/kotlin/Firmament.kt
+++ b/src/main/kotlin/Firmament.kt
@@ -49,6 +49,7 @@ import moe.nea.firmament.features.FeatureManager
 import moe.nea.firmament.gui.config.storage.FirmamentConfigLoader
 import moe.nea.firmament.repo.HypixelStaticData
 import moe.nea.firmament.repo.RepoManager
+import moe.nea.firmament.util.IrisCompat
 import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.SBData
 import moe.nea.firmament.util.mc.InitLevel
@@ -169,8 +170,8 @@ object Firmament {
 			tr("firmament.resourcepack.transparentoverlay", "Transparent Firmament Overlay"),
 			ResourcePackActivationType.NORMAL
 		)
+		IrisCompat.assignPipelines()
 	}
-
 
 	fun identifier(path: String) = Identifier.of(MOD_ID, path)
 	inline fun <reified T : Any> tryDecodeJsonFromStream(inputStream: InputStream): Result<T> {

--- a/src/main/kotlin/util/IrisCompat.kt
+++ b/src/main/kotlin/util/IrisCompat.kt
@@ -1,0 +1,56 @@
+package moe.nea.firmament.util
+
+import com.mojang.blaze3d.pipeline.RenderPipeline
+import java.lang.reflect.Method
+import util.render.CustomRenderPipelines
+import moe.nea.firmament.util.compatloader.CompatLoader
+
+object IrisCompat {
+	private var IRIS_INSTANCE: Any? = null
+	private var IRIS_ASSIGN_PIPELINE_METHOD: Method? = null
+	private var IRIS_PROGRAM_BASIC: Any? = null
+	private var IRIS_PROGRAM_LINES: Any? = null
+	private var IRIS_PROGRAMS_TEXTURED: Any? = null
+	private var IRIS_PROGRAMS_ENTITY: Any? = null
+
+	init {
+		initialize()
+	}
+
+	@CompatLoader.RequireMod("iris")
+	private fun initialize() {
+		try {
+			val irisApiClass = Class.forName("net.irisshaders.iris.api.v0.IrisApi")
+			IRIS_INSTANCE = irisApiClass.getMethod("getInstance").invoke(null)
+			val irisInstanceClass = IRIS_INSTANCE!!.javaClass
+
+			val irisProgramEnum = Class.forName("net.irisshaders.iris.api.v0.IrisProgram")
+			IRIS_PROGRAM_BASIC = java.lang.Enum.valueOf(irisProgramEnum.asSubclass(Enum::class.java), "BASIC")
+			IRIS_PROGRAM_LINES = java.lang.Enum.valueOf(irisProgramEnum.asSubclass(Enum::class.java), "LINES")
+			IRIS_PROGRAMS_TEXTURED = java.lang.Enum.valueOf(irisProgramEnum.asSubclass(Enum::class.java), "TEXTURED")
+
+			IRIS_ASSIGN_PIPELINE_METHOD = irisInstanceClass.getMethod("assignPipeline", RenderPipeline::class.java, irisProgramEnum)
+		} catch (exception: Exception) {
+			exception.printStackTrace()
+		}
+	}
+
+	fun assignPipelines() {
+		assignPipeline(CustomRenderPipelines.GUI_TEXTURED_NO_DEPTH_TRIS, IRIS_PROGRAMS_TEXTURED)
+		assignPipeline(CustomRenderPipelines.OMNIPRESENT_LINES, IRIS_PROGRAM_LINES)
+		assignPipeline(CustomRenderPipelines.COLORED_OMNIPRESENT_QUADS, IRIS_PROGRAM_BASIC)
+		assignPipeline(CustomRenderPipelines.CIRCLE_FILTER_TRANSLUCENT_GUI_TRIS, IRIS_PROGRAMS_TEXTURED)
+		assignPipeline(CustomRenderPipelines.PARALLAX_CAPE_SHADER, IRIS_PROGRAMS_ENTITY)
+	}
+
+	private fun assignPipeline(pipeline: RenderPipeline, enumValue: Any?) {
+		enumValue ?: return
+		IRIS_ASSIGN_PIPELINE_METHOD?.let { method ->
+			try {
+				method.invoke(IRIS_INSTANCE, pipeline, enumValue)
+			} catch (exception: Exception) {
+				exception.printStackTrace()
+			}
+		}
+	}
+}


### PR DESCRIPTION
*Should* allow any Firmament rendering to work when Iris shaders are enabled. I currently cannot run Firmament to test due to a crash I brought up in the discord server, but according to logs it seems to be working. I'm marking this PR as a draft until I (or someone else) can actually test the changes.
<img width="992" height="76" alt="image" src="https://github.com/user-attachments/assets/f17ac84e-ad61-4fa2-963e-838671911f7b" />

fixes #304 