### PR TITLE
Fix: Performance issues with SkyHanni

### DIFF
--- a/src/main/kotlin/util/skyblock/ScreenIdentification.kt
+++ b/src/main/kotlin/util/skyblock/ScreenIdentification.kt
@@ -6,18 +6,13 @@ import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.unformattedString
 
-
 fun Screen.isBazaarUi(): Boolean {
 	if (this !is GenericContainerScreen) return false
-	return (
-		this.screenHandler.stacks[this.screenHandler.rows * 9 - 4]
-			.displayNameAccordingToNbt
-			.unformattedString == "Manage Orders"
-			|| this.screenHandler.stacks[this.screenHandler.rows * 9 - 5]
-			.loreAccordingToNbt
-			.any {
-				it.unformattedString == "To Bazaar"
-			})
+	val screenHandler = this.screenHandler ?: return false
+	val desiredItemSlot = screenHandler.rows * 9 - 4
+	val desiredItem = screenHandler.inventory.getStack(desiredItemSlot)
+	return (desiredItem.displayNameAccordingToNbt.unformattedString == "Manage Orders" ||
+		desiredItem.loreAccordingToNbt.any { it.unformattedString == "To Bazaar" })
 }
 
 fun Screen.isEnchantmentGuide(): Boolean {

--- a/src/main/kotlin/util/skyblock/ScreenIdentification.kt
+++ b/src/main/kotlin/util/skyblock/ScreenIdentification.kt
@@ -9,10 +9,10 @@ import moe.nea.firmament.util.unformattedString
 fun Screen.isBazaarUi(): Boolean {
 	if (this !is GenericContainerScreen) return false
 	val screenHandler = this.screenHandler ?: return false
-	val desiredItemSlot = screenHandler.rows * 9 - 4
-	val desiredItem = screenHandler.inventory.getStack(desiredItemSlot)
-	return (desiredItem.displayNameAccordingToNbt.unformattedString == "Manage Orders" ||
-		desiredItem.loreAccordingToNbt.any { it.unformattedString == "To Bazaar" })
+	val manageOrderStack = screenHandler.inventory.getStack(screenHandler.rows * 9 - 4)
+	if (manageOrderStack.displayNameAccordingToNbt.unformattedString == "Manage Orders") return true
+	val toBazaarStack = screenHandler.inventory.getStack(screenHandler.rows * 9 - 5)
+	return toBazaarStack.loreAccordingToNbt.any { it.unformattedString == "To Bazaar" }
 }
 
 fun Screen.isEnchantmentGuide(): Boolean {


### PR DESCRIPTION
Greaty improves the performance of firmament when skyhanni is installed, this is mainly an issue on SkyHanni's side as we run code on `Slot.getStack()` which is called for each item in the inventory on `screenHandler.getStacks()`. This pr changes the code to only get the specific stack instead of all the stacks then the needed one. [Ive also fixed this on SkyHanni's end](https://github.com/hannibal002/SkyHanni/pull/4774)