### PR TITLE
fix: Skin Preview leaving spaces in skin color id's

### DIFF
--- a/src/main/kotlin/features/debug/SkinPreviews.kt
+++ b/src/main/kotlin/features/debug/SkinPreviews.kt
@@ -52,7 +52,7 @@ object SkinPreviews {
 		val shortened = animation.shortenCycle()
 		if (shortened.size <= (animation.size / 2).coerceAtLeast(1) && lastDiscard.passedTime() > 2.seconds) {
 			val tickEstimation = (lastDiscard.passedTime() / animation.size).toTicks()
-			val skinName = if (skinColor != null) "${skinId}_${skinColor?.uppercase()}" else skinId!!
+			val skinName = if (skinColor != null) "${skinId}_${skinColor?.replace(" ", "_")?.uppercase()}" else skinId!!
 			val json =
 				buildJsonObject {
 					put("ticks", tickEstimation)


### PR DESCRIPTION
Example: 
Copying the Reaper Spectre Black Ice skin would result in `REAPER_SPECTRE_BLACK ICE` instead of `REAPER_SPECTRE_BLACK_ICE`