### PR TITLE
fix storage overlay preview only saving on open

### DIFF
--- a/src/main/kotlin/features/inventory/storageoverlay/StorageOverlay.kt
+++ b/src/main/kotlin/features/inventory/storageoverlay/StorageOverlay.kt
@@ -113,9 +113,9 @@ object StorageOverlay {
 			?: ((it.old as? HandledScreen<*>)?.customGui as? StorageOverlayCustom)?.overview
 		var storageOverviewScreen = it.old as? StorageOverviewScreen
 		val screen = it.new as? GenericContainerScreen
+		rememberContent(currentHandler)
 		val oldHandler = currentHandler
 		currentHandler = StorageBackingHandle.fromScreen(screen)
-		rememberContent(currentHandler)
 		if (storageOverviewScreen != null && oldHandler is StorageBackingHandle.HasBackingScreen) {
 			val player = MC.player
 			assert(player != null)


### PR DESCRIPTION
very small fix to save on leaving a screen rather than when opening it

fixes issues #326 and #322 