### PR TITLE
fix: prevent tooltips rendering for items outside visible content

### DIFF
--- a/src/main/kotlin/features/inventory/storageoverlay/StorageOverlayScreen.kt
+++ b/src/main/kotlin/features/inventory/storageoverlay/StorageOverlayScreen.kt
@@ -533,7 +533,11 @@ class StorageOverlayScreen : Screen(Text.literal("")) {
 				context.drawItem(stack, slotX, slotY)
 				context.drawStackOverlay(textRenderer, stack, slotX, slotY)
 				SlotRenderEvents.After.publish(SlotRenderEvents.After(context, fakeSlot))
-				if (StorageOverlay.TConfig.showInactivePageTooltips && !stack.isEmpty && mouseX >= slotX && mouseY >= slotY && mouseX <= slotX + 16 && mouseY <= slotY + 16) {
+				val rect = getScrollPanelInner()
+				if (StorageOverlay.TConfig.showInactivePageTooltips && !stack.isEmpty &&
+					mouseX >= slotX && mouseY >= slotY &&
+					mouseX <= slotX + 16 && mouseY <= slotY + 16 &&
+					mouseY >= rect.minY && mouseY <= rect.maxY) {
 					try {
 						context.drawItemTooltip(textRenderer, stack, mouseX, mouseY)
 					} catch (e: IllegalStateException) {


### PR DESCRIPTION
A small fix to the storage overlay inactive page tooltips to stop it from rendering tooltips when hovering over items that are above or below the visible content, such as in the screenshot below

<img width="769" height="539" alt="image" src="https://github.com/user-attachments/assets/bc941a67-4b87-42ee-9e6b-549a2ca19f90" />
