### PR TITLE
fix: Catch issue with unreliable api's

### DIFF
--- a/src/main/kotlin/repo/HypixelStaticData.kt
+++ b/src/main/kotlin/repo/HypixelStaticData.kt
@@ -76,10 +76,14 @@ object HypixelStaticData {
 			updateCollectionData()
 		}
 		Firmament.coroutineScope.launch {
-			while (true) {
-				logger.info("Updating NEU prices")
-				fetchPricesFromMoulberry()
-				delay(5.minutes)
+			try {
+				while (true) {
+					logger.info("Updating NEU prices")
+					fetchPricesFromMoulberry()
+					delay(5.minutes)
+				}
+			} catch (ex: Exception) {
+				ex.printStackTrace();
 			}
 		}
 		Firmament.coroutineScope.launch {


### PR DESCRIPTION
Closes #358 

 - Only done to moulberry's api, i assume that if hypixel's api is down this won't be the only problem.
 - Catch any kind of exception to cover as large as possible for the future, currently there's an unstable gateway issue (504) but this could be anything in the future.
 - I've catched outside of the loop to avoid flooding/DDOS of the API if there's already an issue, this preserve the current behavior


