### PR TITLE
feat: add timerinlore to greenhouse next phase

### DIFF
--- a/src/main/kotlin/features/inventory/TimerInLore.kt
+++ b/src/main/kotlin/features/inventory/TimerInLore.kt
@@ -89,6 +89,7 @@ object TimerInLore {
 		TIMEREMAININGS("Time Remaining:", "Ends at"),
 		COOLDOWN("Cooldown:", "Come back at"),
 		ONCOOLDOWN("On cooldown:", "Available at"),
+		GREENHOUSENEXTSTAGE("Next Stage:", "Next stage at"),
 		EVENTENDING("Event ends in:", "Ends at");
 	}
 


### PR DESCRIPTION
Small PR that adds a matching pattern of in-lore timers for the newly released Greenhouse crops' next stage.
<img width="528" height="210" alt="image" src="https://github.com/user-attachments/assets/9e834af4-58bc-4336-977a-18e06413cf83" />
