### PR TITLE
Fix keyboard shortcuts not working in REI recipe overlay screens

### DIFF
--- a/src/compat/rei/java/moe/nea/firmament/mixins/compat/PublishREIOverlayKeyPressEvent.java
+++ b/src/compat/rei/java/moe/nea/firmament/mixins/compat/PublishREIOverlayKeyPressEvent.java
@@ -1,0 +1,36 @@
+package moe.nea.firmament.mixins.compat;
+
+import moe.nea.firmament.events.HandledScreenKeyPressedEvent;
+import moe.nea.firmament.keybindings.GenericInputAction;
+import moe.nea.firmament.keybindings.InputModifiers;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.KeyEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Pseudo;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Publishes HandledScreenKeyPressedEvent for the REI overlay screen.
+ * This ensures that keyboard shortcuts work even when viewing REI recipe/usage screens.
+ * Fires AFTER REI processes the key, so REI's built-in shortcuts take priority.
+ */
+@Mixin(targets = "me.shedaniel.rei.impl.client.gui.ScreenOverlayImpl")
+@Pseudo
+public class PublishREIOverlayKeyPressEvent {
+	@Inject(method = "keyPressed", at = @At("RETURN"))
+	public void onKeyPressed(KeyEvent input, CallbackInfoReturnable<Boolean> cir) {
+		// Only publish event if REI didn't handle the key
+		if (!cir.getReturnValue()) {
+			Screen currentScreen = Minecraft.getInstance().screen;
+			if (currentScreen != null) {
+				HandledScreenKeyPressedEvent.Companion.publish(new HandledScreenKeyPressedEvent(
+					currentScreen,
+					GenericInputAction.of(input),
+					InputModifiers.of(input)));
+			}
+		}
+	}
+}


### PR DESCRIPTION
HandledScreenKeyPressedEvent was not being published when REI's usage/recipe overlay was open, causing features like ItemHotkeys to not work. Added a mixin to publish the event when REI's ScreenOverlayImpl handles key input. The current implementation gives REI priority for Keybinds.

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
As this is AI Code please review it carefully. I reviewed it myself, but I do not have knowledge of the underlying systems (mixins (other than the core concept), key press processing by Minecraft, REI or Firmament and how Minecraft screens work)

Fixes #130 