### PR TITLE
fix: HUDs depending on MoulConfig crashing on first update/render

### DIFF
--- a/src/main/kotlin/gui/hud/MoulConfigHud.kt
+++ b/src/main/kotlin/gui/hud/MoulConfigHud.kt
@@ -19,11 +19,7 @@ abstract class MoulConfigHud(
 ) {
 	companion object {
 		private val componentWrapper by lazy {
-			object : MoulConfigScreenComponent(Component.empty(), GuiContext(TextComponent("§cERROR")), null) {
-				init {
-					this.minecraft = MC.instance
-				}
-			}
+			MoulConfigScreenComponent(Component.empty(), GuiContext(TextComponent("§cERROR")), null)
 		}
 	}
 


### PR DESCRIPTION
Issue: Fixes https://github.com/FirmamentMC/Firmament/issues/2270

Cause: A chat event notifying the player of a Pristine drop triggers an update of the PristineProfitTracker, which updates a MoulConfigHud to show profit data. The MoulConfigHud on render lazy loads a [MoulConfigScreenComponent](https://github.com/NotEnoughUpdates/MoulConfig/blob/e58fcdafdabab0a9cf8b0da9f4c78dd3e5b34780/modern/templates/java/io/github/notenoughupdates/moulconfig/platform/MoulConfigScreenComponent.java#L41) which depends on a Minecraft instance, but initializing it from MoulConfigHud throws an `IllegalAccessError: Update to non-static final field`.

Fix: Deleting the out of scope initialization of field. 
**IMPORTANT**: I am unfamiliar with Minecraft GUIs and cannot verify that a minecraft instance is always initiated by the time an update is called on the HUD. However, since the component is lazy loaded, I assume an instance exists.

Testing: Compiled into jar and triggered pristine event in chat. HUD appears without crashing in the bottom left above chat stating Money and Collection per hour.

<img width="3024" height="1890" alt="image" src="https://github.com/user-attachments/assets/e6d5a377-ed1a-4632-9d0d-cfc4f40eac9a" />
