### PR TITLE
perf: skip redundant lbin price updates based on config

### DIFF
--- a/src/main/kotlin/features/inventory/PriceData.kt
+++ b/src/main/kotlin/features/inventory/PriceData.kt
@@ -77,7 +77,7 @@ object PriceData {
 	fun onItemTooltip(it: ItemTooltipEvent) {
 		if (!TConfig.tooltipEnabled) return
 		if (TConfig.enableKeybinding.isBound && !TConfig.enableKeybinding.isPressed()) return
-		val sbId = it.stack.skyBlockId
+		val sbId = it.stack.skyBlockId ?: return
 		val stackSize = it.stack.getLogicalStackSize()
 		val isShowingStack = TConfig.stackSizeKey.isPressed()
 		val multiplier = if (isShowingStack) stackSize else 1
@@ -89,14 +89,9 @@ object PriceData {
 					"firmament.tooltip.multiply.hint",
 					"[${TConfig.stackSizeKey.format()}] to show x${stackSize}"
 				).darkGrey()
-		val bazaarData = HypixelStaticData.bazaarData[sbId?.asBazaarStock]
+		val bazaarData = HypixelStaticData.bazaarData[sbId.asBazaarStock]
 		val lowestBin = HypixelStaticData.lowestBin[sbId]
-		val avgBinValue: Double? = when (TConfig.avgLowestBin) {
-			AvgLowestBin.ONEDAYAVGLOWESTBIN -> HypixelStaticData.avg1dlowestBin[sbId]
-			AvgLowestBin.THREEDAYAVGLOWESTBIN -> HypixelStaticData.avg3dlowestBin[sbId]
-			AvgLowestBin.SEVENDAYAVGLOWESTBIN -> HypixelStaticData.avg7dlowestBin[sbId]
-			AvgLowestBin.OFF -> null
-		}
+		val avgBinValue = HypixelStaticData.avgLowestBin[sbId].takeIf { TConfig.avgLowestBin != AvgLowestBin.OFF }
 		if (bazaarData != null) {
 			it.lines.add(Component.literal(""))
 			it.lines.add(multiplierText)

--- a/src/main/kotlin/repo/HypixelStaticData.kt
+++ b/src/main/kotlin/repo/HypixelStaticData.kt
@@ -1,8 +1,6 @@
 package moe.nea.firmament.repo
 
 import org.apache.logging.log4j.LogManager
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.launch
@@ -12,6 +10,7 @@ import kotlin.time.Duration.Companion.minutes
 import moe.nea.firmament.Firmament
 import moe.nea.firmament.apis.CollectionResponse
 import moe.nea.firmament.apis.CollectionSkillData
+import moe.nea.firmament.features.inventory.PriceData
 import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.net.HttpUtil
 
@@ -21,11 +20,7 @@ object HypixelStaticData {
 	private val hypixelApiBaseUrl = "https://api.hypixel.net"
 	var lowestBin: Map<SkyblockId, Double> = mapOf()
 		private set
-	var avg1dlowestBin: Map<SkyblockId, Double> = mapOf()
-		private set
-	var avg3dlowestBin: Map<SkyblockId, Double> = mapOf()
-		private set
-	var avg7dlowestBin: Map<SkyblockId, Double> = mapOf()
+	var avgLowestBin: Map<SkyblockId, Double> = mapOf()
 		private set
 	var bazaarData: Map<SkyblockId.BazaarStock, BazaarData> = mapOf()
 		private set
@@ -76,10 +71,10 @@ object HypixelStaticData {
 			updateCollectionData()
 		}
 		Firmament.coroutineScope.launch {
+			fetchPricesFromMoulberry(force = true)
 			while (true) {
-				logger.info("Updating NEU prices")
-				fetchPricesFromMoulberry()
 				delay(5.minutes)
+				fetchPricesFromMoulberry(force = false)
 			}
 		}
 		Firmament.coroutineScope.launch {
@@ -91,15 +86,22 @@ object HypixelStaticData {
 		}
 	}
 
-	private suspend fun fetchPricesFromMoulberry() {
+	private suspend fun fetchPricesFromMoulberry(force: Boolean = false) {
+		if (!PriceData.TConfig.tooltipEnabled && !force) {
+			return
+		}
+		logger.info("Updating NEU prices${if (force) " (forced)" else ""}")
 		lowestBin = HttpUtil.request("$moulberryBaseUrl/lowestbin.json")
 			.forJson<Map<SkyblockId, Double>>().await()
-		avg1dlowestBin = HttpUtil.request("$moulberryBaseUrl/auction_averages_lbin/1day.json")
-			.forJson<Map<SkyblockId, Double>>().await()
-		avg3dlowestBin = HttpUtil.request("$moulberryBaseUrl/auction_averages_lbin/3day.json")
-			.forJson<Map<SkyblockId, Double>>().await()
-		avg7dlowestBin = HttpUtil.request("$moulberryBaseUrl/auction_averages_lbin/7day.json")
-			.forJson<Map<SkyblockId, Double>>().await()
+		when (PriceData.TConfig.avgLowestBin) {
+			PriceData.AvgLowestBin.ONEDAYAVGLOWESTBIN -> "1day.json"
+			PriceData.AvgLowestBin.THREEDAYAVGLOWESTBIN -> "3day.json"
+			PriceData.AvgLowestBin.SEVENDAYAVGLOWESTBIN -> "7day.json"
+			else -> null
+		}?.let { path ->
+			avgLowestBin = HttpUtil.request("$moulberryBaseUrl/auction_averages_lbin/$path")
+				.forJson<Map<SkyblockId, Double>>().await()
+		}
 	}
 
 	private suspend fun fetchBazaarPrices() {


### PR DESCRIPTION
Optimized LBIN fetching to reduce API requests by skipping updates when disabled, while preserving existing data.