### PR TITLE
fix: PublishREIOverlayKeyPressEvent mixin crash

### DIFF
--- a/src/compat/rei/java/moe/nea/firmament/mixins/compat/PublishREIOverlayKeyPressEvent.java
+++ b/src/compat/rei/java/moe/nea/firmament/mixins/compat/PublishREIOverlayKeyPressEvent.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(targets = "me.shedaniel.rei.impl.client.gui.ScreenOverlayImpl")
 @Pseudo
 public class PublishREIOverlayKeyPressEvent {
-	@Inject(method = "keyPressed", at = @At("RETURN"))
+	@Inject(method = {"method_25404", "keyPressed" }, at = @At("RETURN"), require = 0)
 	public void onKeyPressed(KeyEvent input, CallbackInfoReturnable<Boolean> cir) {
 		// Only publish event if REI didn't handle the key
 		if (!cir.getReturnValue()) {

--- a/src/compat/rei/java/moe/nea/firmament/mixins/compat/PublishREIOverlayKeyPressEvent.java
+++ b/src/compat/rei/java/moe/nea/firmament/mixins/compat/PublishREIOverlayKeyPressEvent.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(targets = "me.shedaniel.rei.impl.client.gui.ScreenOverlayImpl")
 @Pseudo
 public class PublishREIOverlayKeyPressEvent {
-	@Inject(method = {"method_25404", "keyPressed" }, at = @At("RETURN"), require = 0)
+	@Inject(method = {"method_25404", "keyPressed"}, at = @At("RETURN"), require = 0)
 	public void onKeyPressed(KeyEvent input, CallbackInfoReturnable<Boolean> cir) {
 		// Only publish event if REI didn't handle the key
 		if (!cir.getReturnValue()) {


### PR DESCRIPTION
slightly jank way to do this. 
I don't think the proper way works without enabling `useLegacyMixinAP`