### PR TITLE
fix: certain islands not being correctly identified as modern

### DIFF
--- a/src/main/kotlin/util/SkyBlockIsland.kt
+++ b/src/main/kotlin/util/SkyBlockIsland.kt
@@ -35,6 +35,7 @@ private constructor(
 		val RIFT = forMode("rift")
 		val PRIVATE_ISLAND = forMode("dynamic")
 		val DUNGEON_HUB = forMode("dungeon_hub")
+		val JERRY_WORKSHOP = forMode("winter")
 
 		// Instanced
 		val DUNGEON = forMode("dungeon")
@@ -70,7 +71,7 @@ private constructor(
 		get() = RepoManager.miningData.customMiningAreas[this]?.isSpecialMining ?: false
 	val isModernServer
 		get() = when(this) {
-			GALATEA, HUB, PRIVATE_ISLAND, FARMING_ISLANDS, SPIDER, END, PARK -> true
+			GALATEA, HUB, PRIVATE_ISLAND, FARMING_ISLANDS, SPIDER, END, PARK, JERRY_WORKSHOP, CRIMSON_ISLE -> true
 			else -> false
 		}
 

--- a/src/main/kotlin/util/SkyBlockIsland.kt
+++ b/src/main/kotlin/util/SkyBlockIsland.kt
@@ -32,22 +32,47 @@ private constructor(
 		private val allIslands = mutableMapOf<String, SkyBlockIsland>()
 		fun forMode(mode: String): SkyBlockIsland = allIslands.computeIfAbsent(mode, ::SkyBlockIsland)
 		val HUB = forMode("hub")
-		val DWARVEN_MINES = forMode("dwarven_mines")
-		val CRYSTAL_HOLLOWS = forMode("crystal_hollows")
-		val CRIMSON_ISLE = forMode("crimson_isle")
-		val PRIVATE_ISLAND = forMode("dynamic")
 		val RIFT = forMode("rift")
-		val MINESHAFT = forMode("mineshaft")
-		val GARDEN = forMode("garden")
+		val PRIVATE_ISLAND = forMode("dynamic")
+		val DUNGEON_HUB = forMode("dungeon_hub")
+
+		// Instanced
 		val DUNGEON = forMode("dungeon")
-		val NIL = forMode("_")
+		val KUUDRA = forMode("kuudra")
+
+		// Mining
+		val GOLD_MINE = forMode("mining_1")
+		val DEEP_CAVERNS = forMode("mining_2")
+		val DWARVEN_MINES = forMode("mining_3")
+		val CRYSTAL_HOLLOWS = forMode("crystal_hollows")
+		val MINESHAFT = forMode("mineshaft")
+
+		// Combat
+		val SPIDER = forMode("combat_1")
+		val END = forMode("combat_3")
+		val CRIMSON_ISLE = forMode("crimson_isle")
+
+		// Farming
+		val FARMING_ISLANDS = forMode("farming_1") // The Barn & Mushroom Desert
+		val GARDEN = forMode("garden")
+
+		// Foraging
+		val PARK = forMode("foraging_1")
 		val GALATEA = forMode("foraging_2")
+
+		// Fishing
+		val BACKWATER_BAYOU = forMode("fishing_1")
+
+		val NIL = forMode("_")
 	}
 
 	val hasCustomMining
 		get() = RepoManager.miningData.customMiningAreas[this]?.isSpecialMining ?: false
 	val isModernServer
-		get() = this == GALATEA
+		get() = when(this) {
+			GALATEA, HUB, PRIVATE_ISLAND, FARMING_ISLANDS, SPIDER, END, PARK -> true
+			else -> false
+		}
 
 	val userFriendlyName
 		get() = RepoManager.neuRepo.constants.islands.areaNames


### PR DESCRIPTION
With the recent Hub change a lot of islands now use 1.21 eye height making Etherwarp overlay incorrect on those islands.
I added some missing islands, sorted them by category, and refactored `isModernServer` to include the islands which have been affected by the update.

Haven't tested Jerry's Workshop since it is currently not available.

More islands are bound to be changed in the future but these are correct for now