### PR TITLE
feat: added multi-level sorting to the REI Item List

### DIFF
--- a/src/compat/rei/java/moe/nea/firmament/compat/rei/FirmamentReiPlugin.kt
+++ b/src/compat/rei/java/moe/nea/firmament/compat/rei/FirmamentReiPlugin.kt
@@ -1,6 +1,7 @@
 package moe.nea.firmament.compat.rei
 
 import io.github.moulberry.repo.data.NEUCraftingRecipe
+import io.github.moulberry.repo.data.NEUItem
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin
 import me.shedaniel.rei.api.client.registry.category.CategoryRegistry
 import me.shedaniel.rei.api.client.registry.display.DisplayRegistry
@@ -15,7 +16,6 @@ import me.shedaniel.rei.api.common.entry.EntryStack
 import me.shedaniel.rei.api.common.entry.type.VanillaEntryTypes
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
-import net.minecraft.client.gui.screens.inventory.MenuAccess
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen
 import net.minecraft.world.item.ItemStack
 import net.minecraft.network.chat.Component
@@ -31,6 +31,7 @@ import moe.nea.firmament.events.HandledScreenPushREIEvent
 import moe.nea.firmament.features.inventory.CraftingOverlay
 import moe.nea.firmament.features.inventory.storageoverlay.StorageOverlayScreen
 import moe.nea.firmament.repo.ExpensiveItemCacheApi
+import moe.nea.firmament.repo.ItemCache
 import moe.nea.firmament.repo.RepoManager
 import moe.nea.firmament.repo.SBItemStack
 import moe.nea.firmament.repo.recipes.SBCraftingRecipeRenderer
@@ -39,8 +40,11 @@ import moe.nea.firmament.repo.recipes.SBForgeRecipeRenderer
 import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.guessRecipeId
+import moe.nea.firmament.util.IntUtil.romanToInt
+import moe.nea.firmament.util.removeColorCodes
 import moe.nea.firmament.util.skyblockId
-import moe.nea.firmament.util.unformattedString
+import moe.nea.firmament.util.skyblock.ItemType
+import moe.nea.firmament.util.skyblock.Rarity
 
 
 class FirmamentReiPlugin : REIClientPlugin {
@@ -74,7 +78,7 @@ class FirmamentReiPlugin : REIClientPlugin {
 			var shouldReturn = true
 			if (context.isActuallyCrafting && !useSuperCraft) {
 				val craftingScreen = (screen as? ContainerScreen)
-					?.takeIf { it.title?.string == CraftingOverlay.CRAFTING_SCREEN_NAME }
+					?.takeIf { it.title.string == CraftingOverlay.CRAFTING_SCREEN_NAME }
 				if (craftingScreen == null) {
 					MC.sendCommand("craft")
 					shouldReturn = false
@@ -108,7 +112,11 @@ class FirmamentReiPlugin : REIClientPlugin {
 	}
 
 	override fun registerExclusionZones(zones: ExclusionZones) {
-		zones.register(AbstractContainerScreen::class.java) { HandledScreenPushREIEvent.publish(HandledScreenPushREIEvent(it)).rectangles }
+		zones.register(AbstractContainerScreen::class.java) {
+			HandledScreenPushREIEvent.publish(
+				HandledScreenPushREIEvent(it)
+			).rectangles
+		}
 		zones.register(StorageOverlayScreen::class.java) { it.getBounds() }
 	}
 
@@ -162,12 +170,179 @@ class FirmamentReiPlugin : REIClientPlugin {
 		registry.registerFocusedStack(SkyblockItemIdFocusedStackProvider)
 	}
 
+	/**
+	 * Parses item display name into base name and tier for proper sorting
+	 * Example: "Sharpness VI" -> ItemNameParts("Sharpness", 6)
+	 */
+	data class BaseNameAndTier(val baseName: String, val tier: Int)
+
+	private enum class PrimaryGroup {
+		TYPED_EXPLICIT, TYPED_OTHER, NAME_BASED_TYPE, LORE_BASED_WITH_RARITY, LORE_BASED_WITHOUT_RARITY
+	}
+
+	private data class SortableItem(
+		val neuItem: NEUItem,
+		val baseNameAndTier: BaseNameAndTier,
+		val effectiveType: String,
+		val primaryGroup: PrimaryGroup,
+	)
+
+	private val minionPattern = Regex("""^.+ Minion [IVXLCDM]+$""")
+	private val potionPattern = Regex("""^.+ [IVXLCDM]+ Potion$""")
+	private val splashPotionPattern = Regex("""^.+ [IVXLCDM]+ Splash Potion$""")
+	private val romanNamePattern = """^(.+?)\s+([IVXLCDM]+)$""".toRegex()
+
+	// Explicit type ordering; types not listed sort alphabetically after these.
+	// Within each group, normal variants come before their DUNGEON counterparts.
+	private val typeOrder = listOf(
+		// -- Item Types --
+		// Armor
+		"HELMET", "DUNGEON HELMET",
+		"CHESTPLATE", "DUNGEON CHESTPLATE",
+		"LEGGINGS", "DUNGEON LEGGINGS",
+		"BOOTS", "DUNGEON BOOTS",
+		// Equipment
+		"NECKLACE", "DUNGEON NECKLACE",
+		"CLOAK", "DUNGEON CLOAK",
+		"BELT", "DUNGEON BELT",
+		"GLOVES", "DUNGEON GLOVES",
+		"BRACELET", "DUNGEON BRACELET",
+		// Weapons
+		"SWORD", "DUNGEON SWORD", "LONGSWORD", "DUNGEON LONGSWORD",
+		"BOW", "DUNGEON BOW", "ARROW",
+		// Tools
+		"PICKAXE", "DUNGEON PICKAXE",
+		"DRILL", "AXE", "SHOVEL", "SHEARS", "FISHING ROD",
+		"DEPLOYABLE", "LASSO", "FISHING NET", "TRAP", 
+        // Pets
+        "PET",
+		// Accessories
+		"ACCESSORY", "DUNGEON ACCESSORY",
+		"HATCESSORY",
+
+		// -- Name Based Types --
+		"ENCHANTED BOOK", "MINION", "POTION", "SPLASH POTION", "SACK",
+	)
+	private val typeOrderIndex: Map<String, Int> = typeOrder.withIndex().associate { (i, t) -> t to i }
+
+	private fun NEUItem.strippedDisplayName() = displayName.removeColorCodes()
+
+	// Dark grey (§8) lore lines that act as a quasi item type (always title-cased in game).
+	private val darkGreyQuasiTypes = setOf(
+		"Brewing Ingredient",
+		"Storage",
+		"Collection Item",
+		"Holiday Cosmetic",
+		"Halloween Cosmetic",
+		"Summer Cosmetic",
+		"Easter Cosmetic",
+		"Decoration Item",
+		"Drill Part",
+		"Basic Brew",
+		"Quest Item",
+	)
+
+	/** Returns a quasi item type from dark grey lore text, or null if none matched. */
+	private fun getQuasiItemType(neuItem: NEUItem): String? {
+		for (i in 0 until minOf(4, neuItem.lore.size)) { // Only expected on first 4 lines
+			val line = neuItem.lore[i]
+			if (!line.startsWith("§8")) continue
+			val plain = line.removeColorCodes().trim()
+			if (plain in darkGreyQuasiTypes) return plain.uppercase()
+		}
+		return null
+	}
+
+	/** Resolves the effective display type and primary group for an item. */
+	@OptIn(ExpensiveItemCacheApi::class)
+	private fun toSortableItem(neuItem: NEUItem): SortableItem {
+		val displayName = neuItem.strippedDisplayName()
+		val itemType = with(ItemCache) { ItemType.fromItemStack(neuItem.asItemStack()) }
+		val namedType = when {
+			minionPattern.matches(displayName) -> "MINION"
+			potionPattern.matches(displayName) -> "POTION"
+			splashPotionPattern.matches(displayName) -> "SPLASH POTION"
+			displayName.endsWith("Sack") -> "SACK"
+			displayName == "Enchanted Book" -> "ENCHANTED BOOK"
+			else -> null
+		}
+		val effectiveType = itemType?.toString()
+			?: namedType
+			?: getQuasiItemType(neuItem)
+			?: "ZZZ"
+		val primaryGroup = when {
+			itemType != null && effectiveType in typeOrderIndex -> PrimaryGroup.TYPED_EXPLICIT
+			itemType != null -> PrimaryGroup.TYPED_OTHER
+			namedType != null -> PrimaryGroup.NAME_BASED_TYPE
+			Rarity.fromEscapeCodeLore(neuItem.lore) != null -> PrimaryGroup.LORE_BASED_WITH_RARITY
+			else -> PrimaryGroup.LORE_BASED_WITHOUT_RARITY
+		}
+		return SortableItem(neuItem, parseItemNameForSorting(neuItem), effectiveType, primaryGroup)
+	}
+
+	private fun parseItemNameForSorting(neuItem: NEUItem): BaseNameAndTier {
+		val displayName = neuItem.strippedDisplayName()
+
+		// For enchanted books the display name is always "Enchanted Book"; the actual
+		// enchant name + level (e.g. "Sharpness V") is in the first lore line.
+		val nameToParse = if (displayName == "Enchanted Book" && neuItem.lore.isNotEmpty()) {
+			neuItem.lore[0].removeColorCodes().trim()
+		} else {
+			displayName
+		}
+
+		// Match pattern like "Sharpness VI" or "Snow Minion XII"
+		val match = romanNamePattern.find(nameToParse)
+
+		return if (match != null) {
+			val (baseName, romanNumeral) = match.destructured
+			val tier = romanNumeral.romanToInt()
+			BaseNameAndTier(baseName, tier)
+		} else {
+			// No tier fallback - use 0 so it sorts before tiered versions
+			BaseNameAndTier(nameToParse, 0)
+		}
+	}
+
+	@OptIn(ExpensiveItemCacheApi::class)
 	override fun registerEntries(registry: EntryRegistry) {
 		if (!RepoManager.shouldLoadREI()) return
 
 		registry.removeEntryIf { true }
-		RepoManager.neuRepo.items?.items?.values?.forEach { neuItem ->
-			registry.addEntry(SBItemEntryDefinition.getEntry(neuItem.skyblockId))
-		}
+
+		// SORTING ORDER:
+		// ┌─ [1] Primary Group:
+		// │   ├─ TYPED_EXPLICIT            — fromItemStack returned a known type in typeOrderIndex
+		// │   ├─ TYPED_OTHER               — fromItemStack returned a type not in typeOrderIndex
+		// │   ├─ NAME_BASED_TYPE           — display-name detected: MINION, POTION, SACK, ENCHANTED BOOK
+		// │   ├─ LORE_BASED_WITH_RARITY 	— dark-grey quasi type (eg. "Decoration Item") and item has a rarity line
+		// │   └─ LORE_BASED_WITHOUT_RARITY — dark-grey quasi type, no rarity line
+		// ├─ [2] Item Type:
+		// │   ├─ TYPED_EXPLICIT: Armor:     HELMET → DUNGEON HELMET → CHESTPLATE → DUNGEON CHESTPLATE
+		// │   │                             LEGGINGS → DUNGEON LEGGINGS → BOOTS → DUNGEON BOOTS
+		// │   │                  Equipment: NECKLACE → DUNGEON NECKLACE → CLOAK → DUNGEON CLOAK
+		// │   │                             BELT → DUNGEON BELT → GLOVES → DUNGEON GLOVES
+		// │   │                             BRACELET → DUNGEON BRACELET
+		// │   │                  Weapons:   SWORD → DUNGEON SWORD → LONGSWORD → DUNGEON LONGSWORD
+		// │   │                             BOW → DUNGEON BOW → ARROW
+		// │   │                  Tools:     PICKAXE → DUNGEON PICKAXE → DRILL → AXE → SHOVEL → SHEARS → FISHING ROD
+		// │   │                             DEPLOYABLE → LASSO → FISHING NET → TRAP → PET
+		// │   │                  Accessory: ACCESSORY → DUNGEON ACCESSORY → HATCESSORY
+		// │   └─ All other groups: alphabetical
+		// ├─ [3] Name (alphabetical)
+		// └─ [4] Tier (I=1, II=2, ...)
+		RepoManager.neuRepo.items?.items?.values
+			?.map { toSortableItem(it) }
+			?.sortedWith(
+				compareBy(
+				{ it.primaryGroup },
+				{ typeOrderIndex[it.effectiveType] ?: Int.MAX_VALUE },
+				{ it.effectiveType },
+				{ it.baseNameAndTier.baseName },
+				{ it.baseNameAndTier.tier }
+			))
+			?.forEach {
+				registry.addEntry(SBItemEntryDefinition.getEntry(it.neuItem.skyblockId))
+			}
 	}
 }

--- a/src/main/kotlin/util/IntUtil.kt
+++ b/src/main/kotlin/util/IntUtil.kt
@@ -9,6 +9,23 @@ object IntUtil {
 		)
 	}
 
+	fun String.romanToInt(): Int {
+		val romanValues = mapOf(
+			'I' to 1, 'V' to 5, 'X' to 10, 'L' to 50,
+			'C' to 100, 'D' to 500, 'M' to 1000
+		)
+
+		var result = 0
+		var prev = 0
+
+		for (char in reversed()) {
+			val curr = romanValues[char] ?: return 0
+			if (curr < prev) result -= curr else result += curr
+			prev = curr
+		}
+		return result
+	}
+
 	// Source: https://stackoverflow.com/questions/19266018/converting-integer-to-roman-numeral converted to Kotlin by Claude
 	fun Int.toRomanNumeral(): String {
 		if (this !in 1..3999) return this.toString()

--- a/src/main/kotlin/util/skyblock/ItemType.kt
+++ b/src/main/kotlin/util/skyblock/ItemType.kt
@@ -1,6 +1,7 @@
 package moe.nea.firmament.util.skyblock
 
 import net.minecraft.world.item.ItemStack
+import moe.nea.firmament.util.darkGreyColor
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.petData
 
@@ -18,11 +19,15 @@ data class ItemType private constructor(val name: String) {
 				?.let(::ofName)
 		}
 
+		// Lore line syntax: [recomb?] [SHINY?] [VERY?] RARITY [DUNGEON?] TYPE1 [TYPE2?] [recomb?] [(ID *)?]
 		fun fromItemStack(itemStack: ItemStack): ItemType? {
 			if (itemStack.petData != null)
 				return PET
 			for (loreLine in itemStack.loreAccordingToNbt) {
-				val words = loreLine.string.split(" ").filter { it.length > 1 } // removes [recomb?]
+				val lineText = loreLine.siblings
+					.takeWhile { it.style.color != darkGreyColor } // removes [(ID *)?] by text color
+					.joinToString("") { it.string }
+				val words = lineText.split(" ").filter { it.length > 1 } // removes [recomb?]
 				if (words.any { word -> word.any { it.isLowerCase() } }) continue // only uppercase
 				val rarityIdx = words.indexOfFirst { Rarity.fromString(it) != null } // skips [SHINY?] [VERY?]
 				if (rarityIdx == -1) continue // no rarity in line

--- a/src/main/kotlin/util/skyblock/Rarity.kt
+++ b/src/main/kotlin/util/skyblock/Rarity.kt
@@ -11,11 +11,11 @@ import net.minecraft.world.item.ItemStack
 import net.minecraft.network.chat.Style
 import net.minecraft.network.chat.Component
 import net.minecraft.ChatFormatting
-import moe.nea.firmament.util.StringUtil.words
 import moe.nea.firmament.util.collections.lastNotNullOfOrNull
+import moe.nea.firmament.util.darkGreyColor
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.petData
-import moe.nea.firmament.util.unformattedString
+import moe.nea.firmament.util.removeColorCodes
 
 typealias RepoRarity = io.github.moulberry.repo.data.Rarity
 
@@ -89,11 +89,25 @@ enum class Rarity(vararg altNames: String) {
 		fun fromPetItem(itemStack: ItemStack): Rarity? =
 			itemStack.petData?.tier?.let(::fromNeuRepo)
 
+
+		private fun rarityFromWords(words: List<String>): Rarity? {
+			if (words.any { word -> word.any { it.isLowerCase() } }) return null
+			return words.firstNotNullOfOrNull(::fromString)
+		}
+
+		// Lore line syntax: [recomb?] [SHINY?] [VERY?] RARITY [DUNGEON?] TYPE [recomb?] [(ID *)?]
 		fun fromLore(lore: List<Component>): Rarity? =
-			lore.lastNotNullOfOrNull {
-				it.unformattedString.words()
-					.firstNotNullOfOrNull(::fromString)
+			lore.lastNotNullOfOrNull { loreLine ->
+				val words = loreLine.siblings
+					.takeWhile { it.style.color != darkGreyColor }
+					.joinToString("") { it.string }
+					.split(" ").filter { it.length > 1 }
+				rarityFromWords(words)
 			}
 
+		fun fromEscapeCodeLore(lore: List<String>): Rarity? =
+			lore.lastNotNullOfOrNull { line ->
+				rarityFromWords(line.removeColorCodes().split(" ").filter { it.length > 1 })
+			}
 	}
 }

--- a/src/main/kotlin/util/textutil.kt
+++ b/src/main/kotlin/util/textutil.kt
@@ -14,6 +14,8 @@ import net.minecraft.network.chat.contents.TranslatableContents
 import net.minecraft.ChatFormatting
 
 
+val darkGreyColor = TextColor.fromLegacyFormat(ChatFormatting.DARK_GRAY)
+
 val formattingChars = "kmolnrKMOLNR".toSet()
 fun CharSequence.removeColorCodes(keepNonColorCodes: Boolean = false): String {
 	var nextParagraph = indexOf('§')


### PR DESCRIPTION


First Page as an example:

<img width="1636" height="2004" alt="Screenshot_20260328_175834" src="https://github.com/user-attachments/assets/9c3073ec-14fc-4cec-aea3-83accace11f9" />

View Sorting Logic in the comment at the bottom of `FirmamentReiPlugin.kt`
Let me know if you have ideas to improve it further or if I missed anything.