### PR TITLE
fix: being unable to export item stacks of modern items

### DIFF
--- a/src/main/kotlin/features/debug/itemeditor/ItemExporter.kt
+++ b/src/main/kotlin/features/debug/itemeditor/ItemExporter.kt
@@ -70,7 +70,9 @@ object ItemExporter {
 			val mut = json.jsonObject.toMutableMap()
 			for (prop in existing) {
 				if (prop.key !in mut || mut[prop.key]!!.let {
-						(it is JsonPrimitive && (it.content.isEmpty() || it.content == "0")) || (it is JsonArray && it.isEmpty()) || (it is JsonObject && it.isEmpty())
+						(it is JsonPrimitive && it.content.isEmpty())
+							|| (it is JsonArray && it.isEmpty())
+							|| (it is JsonObject && it.isEmpty())
 					})
 					mut[prop.key] = prop.value
 			}

--- a/src/main/kotlin/features/debug/itemeditor/LegacyItemExporter.kt
+++ b/src/main/kotlin/features/debug/itemeditor/LegacyItemExporter.kt
@@ -310,9 +310,8 @@ class LegacyItemExporter private constructor(var itemStack: ItemStack) {
 	}
 
 	fun legacyifyItemStack(): LegacyItemData.LegacyItemType {
-		// TODO: add a default here
 		if (itemStack.item == Items.LINGERING_POTION || itemStack.item == Items.SPLASH_POTION)
 			return LegacyItemData.LegacyItemType("potion", 16384)
-		return LegacyItemData.itemLut[itemStack.item]!!
+		return LegacyItemData.itemLut[itemStack.item] ?: LegacyItemData.LegacyItemType(itemStack.item.toString(), 0)
 	}
 }


### PR DESCRIPTION
no clue why they made this a polar bear spawn egg but it broke the exporter
<img width="348" height="133" alt="image" src="https://github.com/user-attachments/assets/1f3cb4e1-e43f-4829-aca8-d6135ca1fb17" />

```java
[15:58:47] [Render thread/ERROR]: Caught exception during processing event HandledScreenKeyPressedEvent(screen=net.minecraft.class_476@6251c23e, input=KeyboardInput(keyCode=267, scanCode=337), modifiers=) by Handler(invocation=fun moe.nea.firmament.features.debug.itemeditor.ItemExporter.onKeyBind(moe.nea.firmament.events.HandledScreenKeyPressedEvent): kotlin.Unit, receivesCancelled=false, knownErrors=[class java.lang.NullPointerException], label=ItemExporter:onKeyBind)
java.lang.NullPointerException
	at knot//moe.nea.firmament.features.debug.itemeditor.LegacyItemExporter.legacyifyItemStack(LegacyItemExporter.kt:316)
	at knot//moe.nea.firmament.features.debug.itemeditor.LegacyItemExporter.exportJson(LegacyItemExporter.kt:221)
	at knot//moe.nea.firmament.features.debug.itemeditor.ItemExporter.exportItem(ItemExporter.kt:53)
	at knot//moe.nea.firmament.features.debug.itemeditor.ItemExporter.onKeyBind(ItemExporter.kt:212)
```