### PR TITLE
fix: don't mutate ItemStack in extraAttributes getter

### DIFF
--- a/src/main/kotlin/features/debug/itemeditor/LegacyItemExporter.kt
+++ b/src/main/kotlin/features/debug/itemeditor/LegacyItemExporter.kt
@@ -200,8 +200,8 @@ class LegacyItemExporter private constructor(var itemStack: ItemStack) {
 
 	fun exportModernSnbt(): Tag {
 		val overlay = ItemStack.CODEC.encodeStart(MC.currentOrDefaultRegistryNbtOps, itemStack.copy().also {
-			it.modifyExtraAttributes { attribs ->
-				originalId.ifPresent { attribs.putString("id", it) }
+			it.modifyExtraAttributes {
+				originalId.ifPresent { putString("id", it) }
 			}
 		}).orThrow
 		val overlayWithVersion =

--- a/src/main/kotlin/repo/SBItemStack.kt
+++ b/src/main/kotlin/repo/SBItemStack.kt
@@ -427,7 +427,7 @@ data class SBItemStack constructor(
 		if (stars == 0) return
 		// TODO: increase stats and add the star level into the nbt data so star displays work
 		itemStack.modifyExtraAttributes {
-			it.putInt("upgrade_level", stars)
+			putInt("upgrade_level", stars)
 		}
 		itemStack.displayNameAccordingToNbt = itemStack.displayNameAccordingToNbt.copy()
 			.append(starString(stars))

--- a/src/main/kotlin/util/SkyblockId.kt
+++ b/src/main/kotlin/util/SkyblockId.kt
@@ -18,25 +18,23 @@ import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.Json
 import kotlin.jvm.optionals.getOrNull
 import net.minecraft.core.component.DataComponents
-import net.minecraft.world.item.component.CustomData
-import net.minecraft.world.item.ItemStack
-import net.minecraft.world.item.Items
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.network.RegistryFriendlyByteBuf
-import net.minecraft.network.codec.StreamCodec
 import net.minecraft.network.codec.ByteBufCodecs
+import net.minecraft.network.codec.StreamCodec
 import net.minecraft.resources.Identifier
+import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
+import net.minecraft.world.item.component.CustomData
 import moe.nea.firmament.repo.ExpLadders
 import moe.nea.firmament.repo.ExpensiveItemCacheApi
 import moe.nea.firmament.repo.ItemCache.asItemStack
 import moe.nea.firmament.repo.ItemNameLookup
 import moe.nea.firmament.repo.RepoManager
-import moe.nea.firmament.repo.set
 import moe.nea.firmament.util.collections.WeakCache
 import moe.nea.firmament.util.json.DashlessUUIDSerializer
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loreAccordingToNbt
-import moe.nea.firmament.util.mc.unsafeNbt
 import moe.nea.firmament.util.skyblock.ScreenIdentification
 import moe.nea.firmament.util.skyblock.ScreenType
 
@@ -128,23 +126,21 @@ data class HypixelPetInfo(
 
 private val jsonparser = Json { ignoreUnknownKeys = true }
 
+/**
+ * Returns a copy of the [ItemStack]'s `minecraft:custom_data` component.
+ *
+ * If you want to modify attributes without replacing the list, use [modifyExtraAttributes].
+ */
 var ItemStack.extraAttributes: CompoundTag
+	get() = get(DataComponents.CUSTOM_DATA)?.copyTag() ?: CompoundTag()
 	set(value) {
 		set(DataComponents.CUSTOM_DATA, CustomData.of(value))
 	}
-	get() {
-		val customData = get(DataComponents.CUSTOM_DATA) ?: run {
-			val component = CustomData.of(CompoundTag())
-			set(DataComponents.CUSTOM_DATA, component)
-			component
-		}
-		return customData.unsafeNbt
-	}
 
-fun ItemStack.modifyExtraAttributes(block: (CompoundTag) -> Unit) {
+fun ItemStack.modifyExtraAttributes(block: CompoundTag.() -> Unit) {
 	val baseNbt = get(DataComponents.CUSTOM_DATA)?.copyTag() ?: CompoundTag()
-	block(baseNbt)
-	set(DataComponents.CUSTOM_DATA, CustomData.of(baseNbt))
+	baseNbt.block()
+	extraAttributes = baseNbt
 }
 
 val ItemStack.skyBlockUUIDString: String?
@@ -206,9 +202,10 @@ val ItemStack.petData: HypixelPetInfo?
 	get() = petDataCache(this).getOrNull()
 
 fun ItemStack.setSkyBlockFirmamentUiId(uiId: String) = setSkyBlockId(SkyblockId("FIRMAMENT_UI_$uiId"))
-fun ItemStack.setSkyBlockId(skyblockId: SkyblockId): ItemStack {
-	this.extraAttributes["id"] = skyblockId.neuItem
-	return this
+fun ItemStack.setSkyBlockId(skyblockId: SkyblockId): ItemStack = apply {
+	modifyExtraAttributes {
+		putString("id", skyblockId.neuItem)
+	}
 }
 
 private val STORED_REGEX = "Stored: ($SHORT_NUMBER_FORMAT)/.+".toPattern()


### PR DESCRIPTION
Changes `ItemStack.extraAttributes` to always return a copy of the `CompoundTag`, and updates any calls that mutate the return value and weren't already using `modifyExtraAttributes`.

Also made `ItemStack.modifyExtraAttributes` take a receiver parameter for cleaner syntax.

Fixes #2277 (in theory, I wasn't actually able to reproduce the bug).