### PR TITLE
fix: clear item model caches more aggressively

### DIFF
--- a/src/main/kotlin/events/CustomItemModelEvent.kt
+++ b/src/main/kotlin/events/CustomItemModelEvent.kt
@@ -28,7 +28,7 @@ data class CustomItemModelEvent(
 
 				inner class IRef(weakInstance: ItemStack, data: IntrospectableItemModelManager) :
 					Ref(weakInstance, data) {
-					override fun shouldBeEvicted(): Boolean = false
+					override fun shouldBeEvicted(): Boolean = !isSimpleStack
 					val isSimpleStack = weakInstance.componentsPatch.isEmpty || (weakInstance.componentsPatch.size() == 1 && weakInstance.get(
 						DataComponents.CUSTOM_DATA)?.isEmpty == true)
 					val item = weakInstance.item


### PR DESCRIPTION
Fixes https://github.com/FirmamentMC/Firmament/issues/2280

<!--


Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->


## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [x] I have not used AI to author code
- [ ] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
