### PR TITLE
fix: crash less aggressively for empty config versions

### DIFF
--- a/src/main/kotlin/gui/config/storage/FirmamentConfigLoader.kt
+++ b/src/main/kotlin/gui/config/storage/FirmamentConfigLoader.kt
@@ -18,6 +18,7 @@ import kotlin.time.Duration.Companion.seconds
 import moe.nea.firmament.annotations.Subscribe
 import moe.nea.firmament.events.TickEvent
 import moe.nea.firmament.features.debug.DebugLogger
+import moe.nea.firmament.util.ErrorUtil
 import moe.nea.firmament.util.SBData.NULL_UUID
 import moe.nea.firmament.util.TimeMark
 import moe.nea.firmament.util.data.IConfigProvider
@@ -58,7 +59,7 @@ object FirmamentConfigLoader {
 					?.listDirectoryEntries()
 					?.filter { it.isDirectory() }
 					?.mapNotNull {
-						val uuid= runCatching { UUID.fromString(it.name) }.getOrNull() ?: return@mapNotNull null
+						val uuid = runCatching { UUID.fromString(it.name) }.getOrNull() ?: return@mapNotNull null
 						uuid to FirstLevelSplitJsonFolder(loadContext, it).load()
 					}
 					?.toMap()
@@ -162,10 +163,13 @@ object FirmamentConfigLoader {
 	val allConfigs: List<IDataHolder<*>> = IConfigProvider.providers.allValidInstances.flatMap { it.configs }
 
 	fun updateConfigs() {
-		val startVersion = configVersionFile.readText()
-			.substringBefore(' ')
-			.trim()
-			.toInt()
+		val configVersionText = configVersionFile.readText()
+		val startVersion = ErrorUtil.catch("Could not parse old config version from '$configVersionText'") {
+			configVersionText
+				.substringBefore(' ')
+				.trim()
+				.toInt()
+		}.or { return }
 		ConfigLoadContext("update-from-$startVersion-to-$currentConfigVersion-${System.currentTimeMillis()}")
 			.use { loadContext ->
 				updateOneConfig(

--- a/src/main/kotlin/gui/config/storage/LegacyImporter.kt
+++ b/src/main/kotlin/gui/config/storage/LegacyImporter.kt
@@ -11,6 +11,7 @@ import kotlin.io.path.moveTo
 import kotlin.io.path.name
 import kotlin.io.path.nameWithoutExtension
 import kotlin.io.path.writeText
+import moe.nea.firmament.Firmament
 import moe.nea.firmament.gui.config.storage.FirmamentConfigLoader.configFolder
 import moe.nea.firmament.gui.config.storage.FirmamentConfigLoader.configVersionFile
 import moe.nea.firmament.gui.config.storage.FirmamentConfigLoader.storageFolder
@@ -32,6 +33,7 @@ object LegacyImporter {
 	)
 
 	fun importFromLegacy() {
+		Firmament.logger.info("Importing legacy config")
 		if (!configFolder.exists()) return
 		configFolder.moveTo(backupPath)
 		configFolder.createDirectories()


### PR DESCRIPTION
https://github.com/FirmamentMC/Firmament/issues/2299

<!--


Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->


## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [x] I have not used AI to author code
- [ ] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
