### PR TITLE
fix: don't try to export recipes in non chests

### DIFF
--- a/src/main/kotlin/features/debug/itemeditor/ExportRecipe.kt
+++ b/src/main/kotlin/features/debug/itemeditor/ExportRecipe.kt
@@ -4,9 +4,10 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import net.minecraft.client.gui.screens.inventory.ContainerScreen
 import net.minecraft.client.player.AbstractClientPlayer
-import net.minecraft.world.entity.decoration.ArmorStand
 import net.minecraft.core.ClientAsset
+import net.minecraft.world.entity.decoration.ArmorStand
 import moe.nea.firmament.Firmament
 import moe.nea.firmament.annotations.Subscribe
 import moe.nea.firmament.events.HandledScreenKeyPressedEvent
@@ -88,6 +89,7 @@ object ExportRecipe {
 		if (!event.matches(PowerUserTools.TConfig.exportUIRecipes)) {
 			return
 		}
+		if (event.screen !is ContainerScreen) return
 		val title = event.screen.title.string
 		val sellSlot = event.screen.getSlotByIndex(49, false)?.item
 		val craftingTableSlot = event.screen.getSlotByIndex(craftingTableSlut, false)


### PR DESCRIPTION
Fixes https://github.com/FirmamentMC/Firmament/issues/2265

<!--


Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->


## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [x] I have not used AI to author code
- [ ] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
