### PR TITLE
fix: recipe exporter attempting to parse annual stock as an item

### DIFF
--- a/src/main/kotlin/features/debug/itemeditor/ExportRecipe.kt
+++ b/src/main/kotlin/features/debug/itemeditor/ExportRecipe.kt
@@ -133,6 +133,7 @@ object ExportRecipe {
 					.dropWhile { it == "Cost" }
 					.takeWhile { it != "Click to trade!" }
 					.takeWhile { it != "Stock" }
+					.takeWhile { !it.startsWith("Annual Stock Year ") }
 					.filter { !it.isBlank() }
 					.map { it.removePrefix("Cost: ") }
 


### PR DESCRIPTION
Fixes "REMAINING:1.0" being added to recipes and this message being put in chat
```
Could not parse cost item Annual Stock Year 487 for Small Witch Cauldron
```


## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.

Hypixel rules:
- I am not aware of a Hypixel rule which my changes would violate.

AI use:
- I have not used AI to author code