### PR TITLE
build: sort owned packages

### DIFF
--- a/build-logic/src/main/kotlin/FabricModTransform.kt
+++ b/build-logic/src/main/kotlin/FabricModTransform.kt
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowCopyAction
+import com.github.jengelman.gradle.plugins.shadow.transformers.CacheableTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.ResourceTransformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
 import com.google.gson.Gson
@@ -13,6 +15,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 
+@CacheableTransformer
 open class FabricModTransform : ResourceTransformer {
 
 	enum class AccessWidenerInclusion : Serializable {
@@ -61,7 +64,7 @@ open class FabricModTransform : ResourceTransformer {
 	}
 
 	override fun hasTransformedResource(): Boolean {
-		return mergedFmj != null
+		return mergedFmj != null || foundAnyAccessWidener
 	}
 
 	override fun modifyOutputStream(os: ZipOutputStream, preserveFileTimestamps: Boolean) {
@@ -69,11 +72,15 @@ open class FabricModTransform : ResourceTransformer {
 		if (foundAnyAccessWidener) {
 			val awFile = mergedFmj["accessWidener"]
 			require(awFile is JsonPrimitive && awFile.isString)
-			os.putNextEntry(ZipEntry(awFile.asString))
+			os.putNextEntry(ZipEntry(awFile.asString).also {
+				it.time = ShadowCopyAction.CONSTANT_TIME_FOR_ZIP_ENTRIES
+			})
 			os.write(foundAccessWideners.write())
 			os.closeEntry()
 		}
-		os.putNextEntry(ZipEntry("fabric.mod.json"))
+		os.putNextEntry(ZipEntry("fabric.mod.json").also {
+			it.time = ShadowCopyAction.CONSTANT_TIME_FOR_ZIP_ENTRIES
+		})
 		os.write(mergedFmj.toString().toByteArray())
 		os.closeEntry()
 	}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -427,15 +427,28 @@ tasks.assemble {
 	dependsOn(apiSourcesJar)
 }
 
+
+/**
+ * This configures a shadow jar task to allow duplicate entries before transformation through [mergeServiceFiles]
+ * or [transform], but to fail if those transformers don't collapse all duplicates.
+ */
+fun ShadowJar.configureDuplicateStrategy() {
+	duplicatesStrategy = DuplicatesStrategy.INCLUDE
+	failOnDuplicateEntries = true
+}
+
 mergedSourceSetsJar.configure {
 	from(zipTree(tasks.jar.flatMap { it.archiveFile }))
 	destinationDirectory.set(layout.buildDirectory.dir("badjars"))
 	archiveClassifier.set("merged-source-sets")
 	mergeServiceFiles()
+	configureDuplicateStrategy()
 }
+
 shadowJar.configure {
 	from(zipTree(tasks.remapJar.flatMap { it.archiveFile }))
 	configurations = listOf(shadowMe)
+	configureDuplicateStrategy()
 	archiveClassifier.set("")
 	relocate("io.github.moulberry.repo", "moe.nea.firmament.deps.repo")
 	relocate("io.github.notenoughupdates.moulconfig", "moe.nea.firmament.deps.moulconfig")

--- a/symbols/src/main/kotlin/process/CompatMetaProcessor.kt
+++ b/symbols/src/main/kotlin/process/CompatMetaProcessor.kt
@@ -12,12 +12,13 @@ import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSName
+import java.util.TreeSet
 
 class CompatMetaProcessor(val logger: KSPLogger, val codeGenerator: CodeGenerator, val sourceSetName: String) :
 	SymbolProcessor {
 	override fun process(resolver: Resolver): List<KSAnnotated> {
 		val files = resolver.getAllFiles().toList()
-		val packages = files.mapTo(mutableSetOf()) { it.packageName.asString() }
+		val packages = files.mapTo(TreeSet()) { it.packageName.asString() }
 		packages.add("moe.nea.firmament.annotations.generated.$sourceSetName")
 		val compatMeta = resolver.getSymbolsWithAnnotation("moe.nea.firmament.util.compatloader.CompatMeta")
 			.singleOrNull() as KSClassDeclaration? ?: return listOf()


### PR DESCRIPTION
just looked at diffoscope and apparently the owned packages set is just randomly sorted. not great, should be deterministic.

<!--


Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->


## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [x] I have not used AI to author code
- [ ] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
