### PR TITLE
fix: don't create an nbt object in itemstacks if one does not already exists

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ firmament.compiletimerepohash=a6116d945491d7c57c93d43f51250f93d62d8434
 
 # TODO: remove after https://github.com/google/ksp/issues/2072
 ksp.incremental=false
-firmament.useHotswap=true
+# firmament.useHotswap=true

--- a/src/main/java/moe/nea/firmament/init/CompoundTagMutationFinalizationDetectorInjector.java
+++ b/src/main/java/moe/nea/firmament/init/CompoundTagMutationFinalizationDetectorInjector.java
@@ -1,0 +1,98 @@
+package moe.nea.firmament.init;
+
+import moe.nea.firmament.util.ErrorUtil;
+import moe.nea.firmament.util.mc.CompoundMutationChecker;
+import net.minecraft.nbt.CompoundTag;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.*;
+
+public class CompoundTagMutationFinalizationDetectorInjector extends RiserUtils {
+	Intermediary.InterClass CompoundTag = Intermediary.<CompoundTag>intermediaryClass();
+	Intermediary.InterClass CompoundMutationChecker = Intermediary.ofClass(CompoundMutationChecker.class);
+	Intermediary.InterMethod checkForMutations = Intermediary.ofMethod(
+		"internalCheckForMutation",
+		CompoundMutationChecker.intermediary().getClassName(),
+		Intermediary.ofClass(Void.TYPE),
+		CompoundTag,
+		CompoundTag
+	);
+	Intermediary.InterClass Object = Intermediary.ofClass(Object.class);
+	public static final String MUTATION_FIELD_NAME = "_firm_mutation_check";
+	public static Type FINALIZE_DESC = Type.getMethodType(Type.VOID_TYPE);
+	public static String FINALIZE_NAME = "finalize";
+
+	@Override
+	public void addTinkerers() {
+		if (!ErrorUtil.aggressiveErrors)
+			return;
+
+		addTransformation(CompoundTag, this::injectFinalizationLogic, false);
+	}
+
+	private void injectFinalizationLogic(ClassNode classNode) {
+		classNode.fields.add(
+			new FieldNode(
+				Opcodes.ACC_PUBLIC,
+				MUTATION_FIELD_NAME,
+				CompoundTag.mapped().getDescriptor(),
+				null,
+				null
+			)
+		);
+
+		classNode.methods.removeIf(it -> it.name.equals(FINALIZE_NAME));
+		classNode.methods.add(constructFinalizationMethod());
+	}
+
+	private MethodNode constructFinalizationMethod() {
+		var node = new MethodNode(
+			Opcodes.ACC_PUBLIC,
+			FINALIZE_NAME,
+			FINALIZE_DESC.getDescriptor(),
+			null,
+			null
+		);
+		var insns = new InsnList();
+		insns.add(new IntInsnNode(Opcodes.ALOAD, 0));
+		insns.add(new FieldInsnNode(
+			Opcodes.GETFIELD,
+			CompoundTag.mapped().getInternalName(),
+			MUTATION_FIELD_NAME,
+			CompoundTag.mapped().getDescriptor()
+		));
+		var sup = new LabelNode();
+		insns.add(new JumpInsnNode(
+			Opcodes.IFNULL,
+			sup
+		));
+		insns.add(new IntInsnNode(Opcodes.ALOAD, 0));
+		insns.add(new IntInsnNode(Opcodes.ALOAD, 0));
+		insns.add(new FieldInsnNode(
+			Opcodes.GETFIELD,
+			CompoundTag.mapped().getInternalName(),
+			MUTATION_FIELD_NAME,
+			CompoundTag.mapped().getDescriptor()
+		));
+		insns.add(new MethodInsnNode(
+			Opcodes.INVOKESTATIC,
+			CompoundMutationChecker.mapped().getInternalName(),
+			checkForMutations.mapped(),
+			checkForMutations.mappedDesc().getDescriptor(),
+			false
+		));
+
+		insns.add(sup);
+		insns.add(new IntInsnNode(Opcodes.ALOAD, 0));
+		insns.add(new MethodInsnNode(
+			Opcodes.INVOKESPECIAL,
+			Object.mapped().getInternalName(),
+			FINALIZE_NAME,
+			FINALIZE_DESC.getDescriptor(),
+			false
+		));
+		insns.add(new InsnNode(Opcodes.RETURN));
+		node.instructions = insns;
+		return node;
+	}
+}

--- a/src/main/java/moe/nea/firmament/init/EarlyRiser.java
+++ b/src/main/java/moe/nea/firmament/init/EarlyRiser.java
@@ -6,6 +6,7 @@ public class EarlyRiser implements Runnable {
     public void run() {
         new HandledScreenRiser().addTinkerers();
         new SectionBuilderRiser().addTinkerers();
+        new CompoundTagMutationFinalizationDetectorInjector().addTinkerers();
 //		TODO: new ItemColorsSodiumRiser().addTinkerers();
     }
 }

--- a/src/main/java/moe/nea/firmament/util/mc/CompoundMutationChecker.java
+++ b/src/main/java/moe/nea/firmament/util/mc/CompoundMutationChecker.java
@@ -1,0 +1,41 @@
+package moe.nea.firmament.util.mc;
+
+import io.github.notenoughupdates.moulconfig.internal.InitUtil;
+import kotlin.Unit;
+import moe.nea.firmament.init.CompoundTagMutationFinalizationDetectorInjector;
+import moe.nea.firmament.util.ErrorUtil;
+import net.minecraft.nbt.CompoundTag;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+public class CompoundMutationChecker {
+	private static final Logger log = LoggerFactory.getLogger(CompoundMutationChecker.class);
+
+	public static void internalCheckForMutation(CompoundTag copy, CompoundTag original) {
+		if (copy.equals(original)) return;
+		log.info("Some code-path modified a not for mutation CompoundTag!\n\nOriginal:\n\n{}\n\nModifier:\n\n{}\n", original, copy);
+	}
+
+	public static class Holder {
+		public static MethodHandle methodHandle = InitUtil.makeUnchecked(
+			() -> MethodHandles.lookup()
+				.findSetter(CompoundTag.class, CompoundTagMutationFinalizationDetectorInjector.MUTATION_FIELD_NAME, CompoundTag.class)
+		);
+	}
+
+
+	public static CompoundTag disallowMutations(CompoundTag compoundTag) {
+		if (ErrorUtil.aggressiveErrors) {
+			var copy = compoundTag.copy();
+			ErrorUtil._catch("Could not insert mutation check", () -> {
+				Holder.methodHandle.invoke(copy, compoundTag);
+				return Unit.INSTANCE;
+			});
+			return copy;
+		}
+		return compoundTag;
+	}
+}

--- a/src/main/kotlin/util/ErrorUtil.kt
+++ b/src/main/kotlin/util/ErrorUtil.kt
@@ -2,6 +2,7 @@
 
 package moe.nea.firmament.util
 
+import io.github.notenoughupdates.moulconfig.internal.InitUtil
 import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
@@ -9,7 +10,8 @@ import moe.nea.firmament.Firmament
 
 @Suppress("NOTHING_TO_INLINE") // Suppressed since i want the logger to not pick up the ErrorUtil stack-frame
 object ErrorUtil {
-	var aggressiveErrors = run {
+	@JvmField
+	val aggressiveErrors = run {
 		TestUtil.isInTest || Firmament.DEBUG
 			|| ErrorUtil::class.java.desiredAssertionStatus()
 	}
@@ -35,6 +37,7 @@ object ErrorUtil {
 	fun logError(message: String, exception: Throwable) {
 		Firmament.logger.error(message, exception)
 	}
+
 	fun logError(message: String) {
 		Firmament.logger.error(message)
 	}
@@ -68,6 +71,10 @@ object ErrorUtil {
 			fun <T> succeed(value: T): Catch<T> = Catch(value, null)
 		}
 	}
+
+	@JvmStatic
+	@JvmName("_catch")
+	fun <T> catch(message: String, block: InitUtil.ThrowingSupplier<T, Throwable>) = catch(message, { block.get() })
 
 	inline fun <T> catch(message: String, block: () -> T): Catch<T> {
 		try {

--- a/src/main/kotlin/util/SkyblockId.kt
+++ b/src/main/kotlin/util/SkyblockId.kt
@@ -133,12 +133,8 @@ var ItemStack.extraAttributes: CompoundTag
 		set(DataComponents.CUSTOM_DATA, CustomData.of(value))
 	}
 	get() {
-		val customData = get(DataComponents.CUSTOM_DATA) ?: run {
-			val component = CustomData.of(CompoundTag())
-			set(DataComponents.CUSTOM_DATA, component)
-			component
-		}
-		return customData.unsafeNbt
+		val customData = get(DataComponents.CUSTOM_DATA)?.unsafeNbt ?: CompoundTag()
+		return customData
 	}
 
 fun ItemStack.modifyExtraAttributes(block: (CompoundTag) -> Unit) {

--- a/src/main/kotlin/util/SkyblockId.kt
+++ b/src/main/kotlin/util/SkyblockId.kt
@@ -34,6 +34,7 @@ import moe.nea.firmament.repo.RepoManager
 import moe.nea.firmament.repo.set
 import moe.nea.firmament.util.collections.WeakCache
 import moe.nea.firmament.util.json.DashlessUUIDSerializer
+import moe.nea.firmament.util.mc.CompoundMutationChecker
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.mc.unsafeNbt
@@ -134,7 +135,7 @@ var ItemStack.extraAttributes: CompoundTag
 	}
 	get() {
 		val customData = get(DataComponents.CUSTOM_DATA)?.unsafeNbt ?: CompoundTag()
-		return customData
+		return CompoundMutationChecker.disallowMutations(customData)
 	}
 
 fun ItemStack.modifyExtraAttributes(block: (CompoundTag) -> Unit) {


### PR DESCRIPTION
Arguably a joke PR. Check using finalizers that the return value of `extraAttributes` does not get mutated.

See also https://github.com/FirmamentMC/Firmament/pull/2301