### PR TITLE
fix: inherit component styles in legacy text export

### DIFF
--- a/src/main/kotlin/util/textutil.kt
+++ b/src/main/kotlin/util/textutil.kt
@@ -93,28 +93,20 @@ fun Component.getLegacyFormatString(trimmed: Boolean = false): String =
 				lastCode = code
 			}
 		}
-		for (component in iterator()) {
-			if (component.directLiteralStringContent.isNullOrEmpty() && component.siblings.isEmpty()) {
-				continue
+		if (!trimmed && directLiteralStringContent == "" && siblings.isNotEmpty()) {
+			appendCode(style.toLegacyFormatString())
+			appendCode("§r")
+		}
+		visit({ style, string ->
+			if (string.isEmpty()) {
+				return@visit Optional.empty<Unit>()
 			}
-			appendCode(component.style.let { style ->
-				var color = style.color?.toChatFormatting()?.toString() ?: "§r"
-				if (style.isBold)
-					color += LegacyFormattingCode.BOLD.formattingCode
-				if (style.isItalic)
-					color += LegacyFormattingCode.ITALIC.formattingCode
-				if (style.isUnderlined)
-					color += LegacyFormattingCode.UNDERLINE.formattingCode
-				if (style.isObfuscated)
-					color += LegacyFormattingCode.OBFUSCATED.formattingCode
-				if (style.isStrikethrough)
-					color += LegacyFormattingCode.STRIKETHROUGH.formattingCode
-				color
-			})
-			sb.append(component.directLiteralStringContent)
+			appendCode(style.toLegacyFormatString())
+			sb.append(string)
 			if (!trimmed)
 				appendCode("§r")
-		}
+			Optional.empty()
+		}, Style.EMPTY)
 		sb.toString()
 	}.also {
 		var it = it
@@ -125,6 +117,21 @@ fun Component.getLegacyFormatString(trimmed: Boolean = false): String =
 		}
 		it
 	}
+
+private fun Style.toLegacyFormatString(): String {
+	var color = color?.toChatFormatting()?.toString() ?: "§r"
+	if (isBold)
+		color += LegacyFormattingCode.BOLD.formattingCode
+	if (isItalic)
+		color += LegacyFormattingCode.ITALIC.formattingCode
+	if (isUnderlined)
+		color += LegacyFormattingCode.UNDERLINE.formattingCode
+	if (isObfuscated)
+		color += LegacyFormattingCode.OBFUSCATED.formattingCode
+	if (isStrikethrough)
+		color += LegacyFormattingCode.STRIKETHROUGH.formattingCode
+	return color
+}
 
 private val textColorLUT = ChatFormatting.entries
 	.mapNotNull { formatting -> formatting.color?.let { it to formatting } }
@@ -212,5 +219,3 @@ fun titleCase(str: String): String {
 			word.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
 		}
 }
-
-

--- a/src/test/kotlin/util/TextUtilText.kt
+++ b/src/test/kotlin/util/TextUtilText.kt
@@ -1,5 +1,7 @@
 package moe.nea.firmament.test.util
 
+import net.minecraft.ChatFormatting
+import net.minecraft.network.chat.Component
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import moe.nea.firmament.test.testutil.ItemResources
@@ -13,6 +15,30 @@ class TextUtilText {
 		Assertions.assertEquals(
 			"§r§r§8[§r§9302§r§8] §r§6♫ §r§b[MVP§r§d+§r§b] lrg89§r§f: test§r",
 			text.getLegacyFormatString()
+		)
+	}
+
+	@Test
+	fun `legacy formatting inherits parent style`() {
+		val text = Component.literal("")
+			.withStyle { it.withItalic(false) }
+			.append(
+				Component.literal("X")
+					.withStyle(ChatFormatting.DARK_PURPLE)
+					.withStyle { it.withObfuscated(true) }
+			)
+			.append(
+				Component.literal(" Rift-Transferable ")
+					.withStyle(ChatFormatting.DARK_PURPLE)
+					.append(
+						Component.literal("X")
+							.withStyle { it.withObfuscated(true) }
+					)
+			)
+
+		Assertions.assertEquals(
+			"§5§kX§5 Rift-Transferable §5§kX",
+			text.getLegacyFormatString(trimmed = true)
 		)
 	}
 }


### PR DESCRIPTION
Fixes #398. I tested it on a few items with funky formatting codes and they all seem to be correct.

<!--


Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->


## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [ ] I have not used AI to author code
- [x] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
