### PR TITLE
feat: allow renaming storage pages

### DIFF
--- a/src/main/kotlin/commands/rome.kt
+++ b/src/main/kotlin/commands/rome.kt
@@ -3,6 +3,7 @@ package moe.nea.firmament.commands
 import com.mojang.brigadier.CommandDispatcher
 import com.mojang.brigadier.arguments.IntegerArgumentType
 import com.mojang.brigadier.arguments.StringArgumentType.string
+import com.mojang.brigadier.builder.LiteralArgumentBuilder
 import java.net.http.HttpResponse
 import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource
 import kotlinx.coroutines.launch
@@ -18,8 +19,10 @@ import moe.nea.firmament.features.debug.DebugLogger
 import moe.nea.firmament.features.debug.DeveloperFeatures
 import moe.nea.firmament.features.debug.PowerUserTools
 import moe.nea.firmament.features.inventory.buttons.InventoryButtons
+import moe.nea.firmament.features.inventory.storageoverlay.StorageOverlay
 import moe.nea.firmament.features.inventory.storageoverlay.StorageOverlayScreen
 import moe.nea.firmament.features.inventory.storageoverlay.StorageOverviewScreen
+import moe.nea.firmament.features.inventory.storageoverlay.StoragePageSlot
 import moe.nea.firmament.features.mining.MiningBlockInfoUi
 import moe.nea.firmament.gui.config.AllConfigsGui
 import moe.nea.firmament.gui.config.BooleanHandler
@@ -45,6 +48,31 @@ import moe.nea.firmament.util.mc.SNbtFormatter
 import moe.nea.firmament.util.tr
 import moe.nea.firmament.util.unformattedString
 
+
+private fun setStorageName(source: DefaultSource, slot: StoragePageSlot, name: String) {
+	StorageOverlay.Data.data.customNames[slot] = name
+	StorageOverlay.Data.markDirty()
+	source.sendFeedback(tr("firmament.command.storagename.set", "Renamed ${slot.defaultName()} to \"$name\"."))
+}
+
+private fun resetStorageName(source: DefaultSource, slot: StoragePageSlot) {
+	StorageOverlay.Data.data.customNames.remove(slot)
+	StorageOverlay.Data.markDirty()
+	source.sendFeedback(tr("firmament.command.storagename.reset", "Reset the name of ${slot.defaultName()}."))
+}
+
+private fun LiteralArgumentBuilder<DefaultSource>.storageNameBranch(
+	type: String,
+	maxPage: Int,
+	toSlot: (Int) -> StoragePageSlot,
+) = thenLiteral(type) {
+	thenArgument("page", IntegerArgumentType.integer(1, maxPage)) { page ->
+		thenExecute { resetStorageName(source, toSlot(this[page])) }
+		thenArgument("name", RestArgumentType) { name ->
+			thenExecute { setStorageName(source, toSlot(this[page]), this[name]) }
+		}
+	}
+}
 
 fun firmamentCommand(ctx: CommandBuildContext) = literal("firmament") {
 	thenLiteral("config") {
@@ -134,6 +162,10 @@ fun firmamentCommand(ctx: CommandBuildContext) = literal("firmament") {
 			ScreenUtil.setScreenLater(StorageOverlayScreen())
 			MC.player?.connection?.sendCommand("storage")
 		}
+	}
+	thenLiteral("storagename") {
+		storageNameBranch("enderchest", 9) { StoragePageSlot.ofEnderChestPage(it) }
+		storageNameBranch("backpack", 18) { StoragePageSlot.ofBackPackPage(it) }
 	}
 	thenLiteral("repo") {
 		thenLiteral("checkpr") {

--- a/src/main/kotlin/features/inventory/storageoverlay/StorageData.kt
+++ b/src/main/kotlin/features/inventory/storageoverlay/StorageData.kt
@@ -10,11 +10,14 @@ import moe.nea.firmament.util.SortedMapSerializer
 
 @Serializable
 data class StorageData(
-    val storageInventories: SortedMap<StoragePageSlot, StorageInventory> = sortedMapOf()
+    val storageInventories: SortedMap<StoragePageSlot, StorageInventory> = sortedMapOf(),
+    val customNames: SortedMap<StoragePageSlot, String> = sortedMapOf(),
 ) {
+    /** The name to show for [slot]: the user assigned name if there is one, otherwise the vanilla default. */
+    fun displayName(slot: StoragePageSlot): String = customNames[slot] ?: slot.defaultName()
+
     @Serializable
     data class StorageInventory(
-        var title: String,
         val slot: StoragePageSlot,
         var inventory: VirtualInventory?,
     )

--- a/src/main/kotlin/features/inventory/storageoverlay/StorageOverlay.kt
+++ b/src/main/kotlin/features/inventory/storageoverlay/StorageOverlay.kt
@@ -175,7 +175,7 @@ object StorageOverlay {
 				continue
 			}
 			if (!isEmpty) {
-				data[slot] = StorageData.StorageInventory(slot.defaultName(), slot, null)
+				data[slot] = StorageData.StorageInventory(slot, null)
 			}
 		}
 		Data.markDirty()
@@ -189,7 +189,6 @@ object StorageOverlay {
 			VirtualInventory(handler.handler.items.take(handler.handler.rowCount * 9).drop(9).map { it.copy() })
 		data.compute(handler.storagePageSlot) { slot, existingInventory ->
 			(existingInventory ?: StorageData.StorageInventory(
-				slot.defaultName(),
 				slot,
 				null
 			)).also {

--- a/src/main/kotlin/features/inventory/storageoverlay/StorageOverlayScreen.kt
+++ b/src/main/kotlin/features/inventory/storageoverlay/StorageOverlayScreen.kt
@@ -515,7 +515,7 @@ class StorageOverlayScreen : Screen(Component.literal("")) {
 			return 18
 		}
 		assertTrueOr(slots == null || slots.size == inv.stacks.size) { return 0 }
-		val name = inventory.title
+		val name = StorageOverlay.Data.data.displayName(page)
 		val pageHeight = inv.rows * SLOT_SIZE + 8 + font.lineHeight
 		if (slots != null && StorageOverlay.TConfig.outlineActiveStoragePage)
 			context.drawAlignedBox(

--- a/src/main/kotlin/features/inventory/storageoverlay/StorageOverviewScreen.kt
+++ b/src/main/kotlin/features/inventory/storageoverlay/StorageOverviewScreen.kt
@@ -107,7 +107,7 @@ class StorageOverviewScreen() : Screen(Component.empty()) {
 	private fun getMaxScroll() = lastRenderedHeight - height + 2 * StorageOverlay.TConfig.margin
 
     private fun renderStoragePage(context: GuiGraphics, page: StorageData.StorageInventory, mouseX: Int, mouseY: Int) {
-        context.drawString(MC.font, page.title, 2, 2, -1, true)
+        context.drawString(MC.font, content.displayName(page.slot), 2, 2, -1, true)
         val inventory = page.inventory
         if (inventory == null) {
             // TODO: Missing texture


### PR DESCRIPTION
Store custom names for ender chests and backpacks separately from the inventory data so they survive a page being emptied, and resolve display names through `StorageData.displayName()`. Add a `/firm storagename` command to set or reset a page name (omit the name to reset to the vanilla default).

## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.

Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.

AI use:

- [ ] I have not used AI to author code
- [x] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.
