### PR TITLE
fix: Etherwarp not using correct the eye height

### DIFF
--- a/src/main/kotlin/features/items/EtherwarpOverlay.kt
+++ b/src/main/kotlin/features/items/EtherwarpOverlay.kt
@@ -15,7 +15,6 @@ import net.minecraft.world.level.BlockGetter
 import moe.nea.firmament.annotations.Subscribe
 import moe.nea.firmament.events.WorldRenderLastEvent
 import moe.nea.firmament.util.MC
-import moe.nea.firmament.util.SBData
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
 import moe.nea.firmament.util.extraAttributes
@@ -173,33 +172,18 @@ object EtherwarpOverlay {
 			{ EtherwarpBlockHit.Miss })
 	}
 
-	enum class EtherwarpItemKind {
-		MERGED,
-		RAW
-	}
-
 	@Subscribe
 	fun renderEtherwarpOverlay(event: WorldRenderLastEvent) {
 		if (!TConfig.etherwarpOverlay) return
 		val player = MC.player ?: return
 		if (TConfig.onlyShowWhileSneaking && !player.isShiftKeyDown) return
-		val world = player.level
+
 		val heldItem = MC.stackInHand
-		val etherwarpTyp = run {
-			if (heldItem.extraAttributes.contains("ethermerge"))
-				EtherwarpItemKind.MERGED
-			else if (heldItem.skyBlockId == SkyBlockItems.ETHERWARP_CONDUIT)
-				EtherwarpItemKind.RAW
-			else
-				return
-		}
-		val playerEyeHeight = // Sneaking: 1.27 (1.21) 1.54 (1.8.9) / Upright: 1.62 (1.8.9,1.21)
-			if (player.isShiftKeyDown || etherwarpTyp == EtherwarpItemKind.MERGED)
-				(if (SBData.skyblockLocation?.isModernServer ?: false) 1.27 else 1.54)
-			else 1.62
-		val playerEyePos = player.position.add(0.0, playerEyeHeight, 0.0)
-		val start = playerEyePos
-		val end = player.getViewVector(0F).scale(160.0).add(playerEyePos)
+		if (!heldItem.extraAttributes.contains("ethermerge") && heldItem.skyBlockId != SkyBlockItems.ETHERWARP_CONDUIT) return
+
+		val world = player.level
+		val start = player.eyePosition
+		val end = player.getViewVector(0F).scale(160.0).add(start)
 		val hitResult = raycastWithEtherwarpTransparency(
 			world,
 			start,
@@ -212,7 +196,7 @@ object EtherwarpOverlay {
 				EtherwarpResult.OCCUPIED
 			else if (!isEtherwarpTransparent(world, blockPos.above(2)))
 				EtherwarpResult.OCCUPIED
-			else if (playerEyePos.distanceToSqr(hitResult.accuratePos ?: blockPos.center) > 61 * 61)
+			else if (start.distanceToSqr(hitResult.accuratePos ?: blockPos.center) > 61 * 61)
 				EtherwarpResult.TOO_DISTANT
 			else if ((MC.instance.hitResult as? BlockHitResult)
 					?.takeIf { it.type == HitResult.Type.BLOCK }

--- a/src/main/kotlin/util/SkyBlockIsland.kt
+++ b/src/main/kotlin/util/SkyBlockIsland.kt
@@ -69,11 +69,6 @@ private constructor(
 
 	val hasCustomMining
 		get() = RepoManager.miningData.customMiningAreas[this]?.isSpecialMining ?: false
-	val isModernServer
-		get() = when(this) {
-			GALATEA, HUB, PRIVATE_ISLAND, FARMING_ISLANDS, SPIDER, END, PARK, JERRY_WORKSHOP, CRIMSON_ISLE -> true
-			else -> false
-		}
 
 	val userFriendlyName
 		get() = RepoManager.neuRepo.constants.islands.areaNames


### PR DESCRIPTION
June 1st Patch: https://hypixel.net/threads/june-1-skyblock-patch-notes.6104669/
all islands are now modern so no need to calculate for different eye heights.

I removed the etherwarpType variable and EtherwarpItemKind enum since they were no longer in use.
they could still be useful since I believe the Etherwarp conduit has a shorter range but I am too poor to verify.

<!--

Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->


## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [x] I have not used AI to author code
- [ ] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->