### PR TITLE
fix: npc stub exporter not working + feat: improve stub exporting for non-player entities

### DIFF
--- a/src/main/kotlin/features/debug/itemeditor/ExportRecipe.kt
+++ b/src/main/kotlin/features/debug/itemeditor/ExportRecipe.kt
@@ -5,8 +5,6 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
-import net.minecraft.client.player.AbstractClientPlayer
-import net.minecraft.core.ClientAsset
 import net.minecraft.world.entity.decoration.ArmorStand
 import moe.nea.firmament.Firmament
 import moe.nea.firmament.annotations.Subscribe
@@ -23,7 +21,6 @@ import moe.nea.firmament.util.ifDropLast
 import moe.nea.firmament.util.mc.ScreenUtil.getSlotByIndex
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loreAccordingToNbt
-import moe.nea.firmament.util.mc.setSkullOwner
 import moe.nea.firmament.util.parseShortNumber
 import moe.nea.firmament.util.red
 import moe.nea.firmament.util.removeColorCodes
@@ -67,12 +64,7 @@ object ExportRecipe {
 				?: ""
 			val reply = waitForTextInput("$guessName (NPC)", "Export stub")
 			val id = generateName(reply)
-			ItemExporter.exportStub(id, "§9$reply") {
-				val playerEntity = entity as? AbstractClientPlayer
-				val textureUrl = (playerEntity?.skin?.body as? ClientAsset.DownloadedTexture)?.url
-				if (textureUrl != null)
-					it.setSkullOwner(playerEntity.uuid, textureUrl)
-			}
+			ItemExporter.exportStub(id, "§9$reply", entity)
 			ItemExporter.modifyJson(id) {
 				val mutJson = it.toMutableMap()
 				mutJson["island"] = JsonPrimitive(SBData.skyblockLocation?.locrawMode ?: "unknown")
@@ -121,8 +113,7 @@ object ExportRecipe {
 		) {
 			val shopId = SkyblockId(title.uppercase().replace(" ", "_") + "_NPC")
 			if (!ItemExporter.isExported(shopId)) {
-				// TODO: export location + skin of last clicked npc
-				ItemExporter.exportStub(shopId, "§9$title (NPC)")
+				ItemExporter.exportStub(shopId, "§9$title (NPC)", MC.instance.crosshairPickEntity)
 			}
 			for (index in (9..9 * 5)) {
 				val item = event.screen.getSlotByIndex(index, false)?.item ?: continue

--- a/src/main/kotlin/features/debug/itemeditor/ItemExporter.kt
+++ b/src/main/kotlin/features/debug/itemeditor/ItemExporter.kt
@@ -271,12 +271,13 @@ object ItemExporter {
 	}
 
 	fun exportStub(skyblockId: SkyblockId, title: String, extra: (ItemStack) -> Unit = {}) {
-		exportItem(ItemStack(Items.PLAYER_HEAD).also {
+		val exportText = exportItem(ItemStack(Items.PLAYER_HEAD).also {
 			it.displayNameAccordingToNbt = Component.literal(title)
 			it.loreAccordingToNbt = listOf(Component.literal(""))
 			it.setSkyBlockId(skyblockId)
 			extra(it) // LOL
 		})
+		MC.sendChat(exportText)
 		MC.sendChat(tr("firmament.repo.export.stub", "Exported a stub item for $skyblockId"))
 	}
 }

--- a/src/main/kotlin/features/debug/itemeditor/ItemExporter.kt
+++ b/src/main/kotlin/features/debug/itemeditor/ItemExporter.kt
@@ -12,11 +12,15 @@ import kotlin.io.path.notExists
 import kotlin.io.path.readText
 import kotlin.io.path.relativeTo
 import kotlin.io.path.writeText
-import net.minecraft.world.item.ItemStack
-import net.minecraft.world.item.Items
+import net.minecraft.client.player.AbstractClientPlayer
+import net.minecraft.core.ClientAsset
 import net.minecraft.nbt.StringTag
 import net.minecraft.network.chat.Component
+import net.minecraft.world.entity.Entity
 import net.minecraft.world.item.AxeItem
+import net.minecraft.world.item.Item
+import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
 import moe.nea.firmament.Firmament
 import moe.nea.firmament.annotations.Subscribe
 import moe.nea.firmament.commands.RestArgumentType
@@ -40,6 +44,7 @@ import moe.nea.firmament.util.focusedItemStack
 import moe.nea.firmament.util.mc.SNbtFormatter.Companion.toPrettyString
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loreAccordingToNbt
+import moe.nea.firmament.util.mc.setSkullOwner
 import moe.nea.firmament.util.mc.toNbtList
 import moe.nea.firmament.util.render.drawGuiTexture
 import moe.nea.firmament.util.setSkyBlockId
@@ -270,12 +275,23 @@ object ItemExporter {
 			)
 	}
 
-	fun exportStub(skyblockId: SkyblockId, title: String, extra: (ItemStack) -> Unit = {}) {
-		val exportText = exportItem(ItemStack(Items.PLAYER_HEAD).also {
+	fun getItemForEntity(entity: Entity?): Item {
+		if (entity == null) return Items.BARRIER
+		if (entity is AbstractClientPlayer) return Items.PLAYER_HEAD
+		return entity.pickResult?.item ?: Items.BARRIER
+	}
+
+	fun exportStub(skyblockId: SkyblockId, title: String, entity: Entity?) {
+		val exportText = exportItem(ItemStack(getItemForEntity(entity)).also {
 			it.displayNameAccordingToNbt = Component.literal(title)
 			it.loreAccordingToNbt = listOf(Component.literal(""))
 			it.setSkyBlockId(skyblockId)
-			extra(it) // LOL
+			if (it.`is`(Items.PLAYER_HEAD)) {
+				val playerEntity = entity as? AbstractClientPlayer
+				val textureUrl = (playerEntity?.skin?.body as? ClientAsset.DownloadedTexture)?.url
+				if (textureUrl != null)
+					it.setSkullOwner(playerEntity.uuid, textureUrl)
+			}
 		})
 		MC.sendChat(exportText)
 		MC.sendChat(tr("firmament.repo.export.stub", "Exported a stub item for $skyblockId"))

--- a/src/main/kotlin/util/SkyblockId.kt
+++ b/src/main/kotlin/util/SkyblockId.kt
@@ -18,14 +18,14 @@ import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.Json
 import kotlin.jvm.optionals.getOrNull
 import net.minecraft.core.component.DataComponents
-import net.minecraft.world.item.component.CustomData
-import net.minecraft.world.item.ItemStack
-import net.minecraft.world.item.Items
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.network.RegistryFriendlyByteBuf
-import net.minecraft.network.codec.StreamCodec
 import net.minecraft.network.codec.ByteBufCodecs
+import net.minecraft.network.codec.StreamCodec
 import net.minecraft.resources.Identifier
+import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
+import net.minecraft.world.item.component.CustomData
 import moe.nea.firmament.repo.ExpLadders
 import moe.nea.firmament.repo.ExpensiveItemCacheApi
 import moe.nea.firmament.repo.ItemCache.asItemStack
@@ -204,7 +204,9 @@ val ItemStack.petData: HypixelPetInfo?
 
 fun ItemStack.setSkyBlockFirmamentUiId(uiId: String) = setSkyBlockId(SkyblockId("FIRMAMENT_UI_$uiId"))
 fun ItemStack.setSkyBlockId(skyblockId: SkyblockId): ItemStack {
-	this.extraAttributes["id"] = skyblockId.neuItem
+	modifyExtraAttributes { tag ->
+		tag["id"] = skyblockId.neuItem
+	}
 	return this
 }
 
@@ -242,7 +244,7 @@ fun ItemStack.guessContextualSkyBlockId(): SkyblockId? {
 		return ItemNameLookup.guessItemByName(name, false)
 	}
 	if (screenType == ScreenType.EXPERIMENTATION_RNG_METER
-			|| screenType == ScreenType.ENCHANTMENT_GUIDE
+		|| screenType == ScreenType.ENCHANTMENT_GUIDE
 	) {
 		val name = displayNameAccordingToNbt.unformattedString
 		return RepoManager.enchantedBookCache.byName[name]


### PR DESCRIPTION
the fix is a little jank, but stub exporting broke with https://github.com/FirmamentMC/Firmament/commit/d7f2ee7df135782842fd8ab5dd95dab6644062bd.
it also now adds the chat message from item exporting, as the current system does not let you know at all if there is an error.

with this, it will set the repo item to the spawn egg of the mob if it is not a player entity, instead of a default steve head.

## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.

Hypixel rules:
- I am not aware of a Hypixel rule which my changes would violate.

AI use:
- I have not used AI to author code