### PR TITLE
refactor: make use of LazyItemStack as a bridge between ItemTemplate …

### DIFF
--- a/src/compat/jade/java/moe/nea/firmament/compat/jade/DrillToolProvider.kt
+++ b/src/compat/jade/java/moe/nea/firmament/compat/jade/DrillToolProvider.kt
@@ -19,9 +19,10 @@ import moe.nea.firmament.repo.ExpensiveItemCacheApi
 import moe.nea.firmament.repo.RepoManager
 import moe.nea.firmament.repo.SBItemStack
 import moe.nea.firmament.util.MC
+import moe.nea.firmament.util.mc.RequiresComponents
 
 class DrillToolProvider : IBlockComponentProvider {
-	@OptIn(ExpensiveItemCacheApi::class)
+	@OptIn(ExpensiveItemCacheApi::class, RequiresComponents::class)
 	override fun appendTooltip(
 		tooltip: ITooltip,
 		accessor: BlockAccessor,
@@ -47,7 +48,7 @@ class DrillToolProvider : IBlockComponentProvider {
 				}
 				innerMut.set(
 					lastItemIndex, JadeUI
-						.item(tool, 0.75f)
+						.item(tool.upgrade(), 0.75f)
 				)
 				innerMut.subList(0, lastItemIndex - 1).removeIf { it is ItemStackElement }
 				innerMut

--- a/src/compat/rei/java/moe/nea/firmament/compat/rei/FirmamentReiPlugin.kt
+++ b/src/compat/rei/java/moe/nea/firmament/compat/rei/FirmamentReiPlugin.kt
@@ -39,6 +39,7 @@ import moe.nea.firmament.repo.recipes.SBForgeRecipeRenderer
 import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.guessRecipeId
+import moe.nea.firmament.util.mc.RequiresComponents
 import moe.nea.firmament.util.skyblockId
 import moe.nea.firmament.util.unformattedString
 
@@ -46,9 +47,10 @@ import moe.nea.firmament.util.unformattedString
 class FirmamentReiPlugin : REIClientPlugin {
 
 	companion object {
+		@RequiresComponents
 		@ExpensiveItemCacheApi
 		fun EntryStack<SBItemStack>.asItemEntry(): EntryStack<ItemStack> {
-			return EntryStack.of(VanillaEntryTypes.ITEM, value.asImmutableItemStack())
+			return EntryStack.of(VanillaEntryTypes.ITEM, value.asImmutableItemStack().upgrade())
 		}
 
 		val SKYBLOCK_ITEM_TYPE_ID = Identifier.fromNamespaceAndPath("firmament", "skyblockitems")

--- a/src/compat/rei/java/moe/nea/firmament/compat/rei/NEUItemEntryRenderer.kt
+++ b/src/compat/rei/java/moe/nea/firmament/compat/rei/NEUItemEntryRenderer.kt
@@ -30,13 +30,15 @@ import moe.nea.firmament.util.ErrorUtil
 import moe.nea.firmament.util.FirmFormatters
 import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.darkGrey
+import moe.nea.firmament.util.mc.RequiresComponents
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 
 // TODO: make this re implement BatchedEntryRenderer, if possible (likely not, due to no-alloc rendering)
 // Also it is probably not even that much faster now, with render layers.
 object NEUItemEntryRenderer : EntryRenderer<SBItemStack> {
-	@OptIn(ExpensiveItemCacheApi::class)
+	@OptIn(ExpensiveItemCacheApi::class, RequiresComponents::class)
 	override fun render(
 		entry: EntryStack<SBItemStack>,
 		context: GuiGraphics,
@@ -50,7 +52,7 @@ object NEUItemEntryRenderer : EntryRenderer<SBItemStack> {
 			ItemCache.recacheSoon(neuItem)
 			ItemStack(Items.PAINTING)
 		} else {
-			entry.value.asImmutableItemStack()
+			entry.value.asImmutableItemStack().upgrade()
 		}
 
 		context.pose().pushMatrix()
@@ -71,7 +73,7 @@ object NEUItemEntryRenderer : EntryRenderer<SBItemStack> {
 	val minecraft = Minecraft.getInstance()
 	var canUseVanillaTooltipEvents = true
 
-	@OptIn(ExpensiveItemCacheApi::class)
+	@OptIn(ExpensiveItemCacheApi::class, RequiresComponents::class)
 	override fun getTooltip(entry: EntryStack<SBItemStack>, tooltipContext: TooltipContext): Tooltip? {
 		if (!entry.value.isWarm() && !RepoManager.TConfig.perfectRenders.rendersPerfectText()) {
 			val neuItem = entry.value.neuItem
@@ -83,10 +85,10 @@ object NEUItemEntryRenderer : EntryRenderer<SBItemStack> {
 			}
 		}
 
-		val stack = entry.value.asImmutableItemStack()
+		val stack = entry.value.asImmutableItemStack().upgrade() // TODO: this shouldnt upgrade if possible, or check for upgradability, otherwise we risk a too fast repo, with a too slow REI tooltip indexer crashing us here
 
-		val lore = mutableListOf(stack.displayNameAccordingToNbt)
-		lore.addAll(stack.loreAccordingToNbt)
+		val lore = mutableListOf(stack.accessor().displayNameAccordingToNbt)
+		lore.addAll(stack.accessor().loreAccordingToNbt)
 		if (canUseVanillaTooltipEvents) {
 			try {
 				ItemTooltipCallback.EVENT.invoker().getTooltip(

--- a/src/compat/rei/java/moe/nea/firmament/compat/rei/SBItemEntryDefinition.kt
+++ b/src/compat/rei/java/moe/nea/firmament/compat/rei/SBItemEntryDefinition.kt
@@ -19,15 +19,17 @@ import moe.nea.firmament.repo.ExpensiveItemCacheApi
 import moe.nea.firmament.repo.RepoManager
 import moe.nea.firmament.repo.SBItemStack
 import moe.nea.firmament.util.SkyblockId
+import moe.nea.firmament.util.mc.LazyItemStack
+import moe.nea.firmament.util.mc.RequiresComponents
 
 object SBItemEntryDefinition : EntryDefinition<SBItemStack> {
 	override fun equals(o1: SBItemStack, o2: SBItemStack, context: ComparisonContext): Boolean {
 		return o1.skyblockId == o2.skyblockId && o1.getStackSize() == o2.getStackSize()
 	}
 
-	@OptIn(ExpensiveItemCacheApi::class)
+	@OptIn(ExpensiveItemCacheApi::class, RequiresComponents::class)
 	override fun cheatsAs(entry: EntryStack<SBItemStack>?, value: SBItemStack): ItemStack {
-		return value.asCopiedItemStack()
+		return value.asImmutableItemStack().copiedUpgrade()
 	}
 
 	override fun getValueType(): Class<SBItemStack> = SBItemStack::class.java
@@ -43,11 +45,11 @@ object SBItemEntryDefinition : EntryDefinition<SBItemStack> {
 		return Stream.empty()
 	}
 
-	@OptIn(ExpensiveItemCacheApi::class)
+	@OptIn(ExpensiveItemCacheApi::class, RequiresComponents::class)
 	override fun asFormattedText(entry: EntryStack<SBItemStack>, value: SBItemStack): Component {
 		val neuItem = entry.value.neuItem
 		return if (!RepoManager.TConfig.perfectRenders.rendersPerfectText() || entry.value.isWarm() || neuItem == null) {
-			VanillaEntryTypes.ITEM.definition.asFormattedText(entry.asItemEntry(), value.asImmutableItemStack())
+			VanillaEntryTypes.ITEM.definition.asFormattedText(entry.asItemEntry(), value.asImmutableItemStack().upgrade())
 		} else {
 			Component.literal(neuItem.displayName)
 		}
@@ -90,7 +92,7 @@ object SBItemEntryDefinition : EntryDefinition<SBItemStack> {
 	fun getEntry(ingredient: NEUIngredient): EntryStack<SBItemStack> =
 		getEntry(SkyblockId(ingredient.itemId), count = ingredient.amount.toInt())
 
-	fun getPassthrough(item: ItemLike) = getEntry(SBItemStack.passthrough(ItemStack(item.asItem())))
+	fun getPassthrough(item: ItemLike) = getEntry(SBItemStack.passthrough(LazyItemStack.build(item)))
 
 	fun getEntry(stack: ItemStack): EntryStack<SBItemStack> =
 		getEntry(SBItemStack(stack))

--- a/src/main/kotlin/events/ComponentsLoadedEvent.kt
+++ b/src/main/kotlin/events/ComponentsLoadedEvent.kt
@@ -4,7 +4,7 @@ import moe.nea.firmament.annotations.Subscribe
 
 class ComponentsLoadedEvent : FirmamentEvent() {
 	companion object : FirmamentEventBus<ComponentsLoadedEvent>() {
-		var generation = 0
+		var generation = -1
 
 		@Subscribe
 		fun onComponentsLoaded(event: ComponentsLoadedEvent) {

--- a/src/main/kotlin/features/debug/PowerUserTools.kt
+++ b/src/main/kotlin/features/debug/PowerUserTools.kt
@@ -39,6 +39,7 @@ import moe.nea.firmament.util.grey
 import moe.nea.firmament.util.mc.IntrospectableItemModelManager
 import moe.nea.firmament.util.mc.SNbtFormatter
 import moe.nea.firmament.util.mc.SNbtFormatter.Companion.toPrettyString
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.iterableArmorItems
 import moe.nea.firmament.util.mc.loreAccordingToNbt
@@ -88,7 +89,7 @@ object PowerUserTools {
 	}
 
 	fun debugFormat(itemStack: ItemStack): Component {
-		return Component.literal(itemStack.skyBlockId?.toString() ?: itemStack.toString())
+		return Component.literal(itemStack.accessor().skyBlockId?.toString() ?: itemStack.toString())
 	}
 
 	@Subscribe
@@ -144,8 +145,9 @@ object PowerUserTools {
 	fun copyInventoryInfo(it: HandledScreenKeyPressedEvent) {
 		if (it.screen !is AccessorHandledScreen) return
 		val item = it.screen.focusedItemStack ?: return
+		val accessor = item.accessor()
 		if (it.matches(TConfig.copyItemId)) {
-			val sbId = item.skyBlockId
+			val sbId = accessor.skyBlockId
 			if (sbId == null) {
 				lastCopiedStack = Pair(item, Component.translatable("firmament.tooltip.copied.skyblockid.fail"))
 				return
@@ -172,8 +174,8 @@ object PowerUserTools {
 			ClipboardUtils.setTextContent(nbt)
 			lastCopiedStack = Pair(item, Component.translatable("firmament.tooltip.copied.nbt"))
 		} else if (it.matches(TConfig.copyLoreData)) {
-			val list = mutableListOf(item.displayNameAccordingToNbt)
-			list.addAll(item.loreAccordingToNbt)
+			val list = mutableListOf(accessor.displayNameAccordingToNbt)
+			list.addAll(accessor.loreAccordingToNbt)
 			ClipboardUtils.setTextContent(list.joinToString("\n") {
 				ComponentSerialization.CODEC.encodeStart(JsonOps.INSTANCE, it).result().getOrNull().toString()
 			})
@@ -246,7 +248,7 @@ object PowerUserTools {
 	@Subscribe
 	fun addItemId(it: ItemTooltipEvent) {
 		if (TConfig.showItemIds) {
-			val id = it.stack.skyBlockId ?: return
+			val id = it.stack.accessor().skyBlockId ?: return
 			it.lines.add(Component.translatableEscape("firmament.tooltip.skyblockid", id.neuItem).grey())
 		}
 		val (item, text) = lastCopiedStack ?: return

--- a/src/main/kotlin/features/debug/SkinPreviews.kt
+++ b/src/main/kotlin/features/debug/SkinPreviews.kt
@@ -19,6 +19,7 @@ import moe.nea.firmament.util.TimeMark
 import moe.nea.firmament.util.extraAttributes
 import moe.nea.firmament.util.json.toJsonArray
 import moe.nea.firmament.util.math.GChainReconciliation.shortenCycle
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.rawSkyBlockId
@@ -74,13 +75,14 @@ object SkinPreviews {
 	@Subscribe
 	fun onActivate(event: IsSlotProtectedEvent) {
 		if (!PowerUserTools.TConfig.autoCopyAnimatedSkins) return
-		val lastLine = event.itemStack.loreAccordingToNbt.lastOrNull()?.string
+		val accessor = event.itemStack.accessor()
+		val lastLine = accessor.loreAccordingToNbt.lastOrNull()?.string
 		if (lastLine != "Right-click to preview!" && lastLine != "Click to preview!") return
 		lastDiscard = TimeMark.now()
-		val stackName = event.itemStack.displayNameAccordingToNbt.string
+		val stackName = accessor.displayNameAccordingToNbt.string
 		if (stackName == "FIRE SALE!") {
 			skinColor = null
-			skinId = event.itemStack.rawSkyBlockId
+			skinId = accessor.rawSkyBlockId
 		} else {
 			skinColor = stackName
 		}

--- a/src/main/kotlin/features/debug/itemeditor/ExportRecipe.kt
+++ b/src/main/kotlin/features/debug/itemeditor/ExportRecipe.kt
@@ -19,7 +19,9 @@ import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.async.waitForTextInput
 import moe.nea.firmament.util.ifDropLast
 import moe.nea.firmament.util.mc.ScreenUtil.getSlotByIndex
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
+import moe.nea.firmament.util.mc.isEmpty
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.parseShortNumber
 import moe.nea.firmament.util.red
@@ -83,19 +85,19 @@ object ExportRecipe {
 		}
 		if (event.screen !is ContainerScreen) return
 		val title = event.screen.title.string
-		val sellSlot = event.screen.getSlotByIndex(49, false)?.item
+		val sellSlot = event.screen.getSlotByIndex(49, false)?.item?.accessor()
 		val craftingTableSlot = event.screen.getSlotByIndex(craftingTableSlut, false)
-		if (craftingTableSlot?.item?.displayNameAccordingToNbt?.unformattedString == "Crafting Table") {
+		if (craftingTableSlot?.item?.accessor()?.displayNameAccordingToNbt?.unformattedString == "Crafting Table") {
 			slotIndices.forEach { (_, index) ->
 				event.screen.getSlotByIndex(index, false)?.item?.let(ItemExporter::ensureExported)
 			}
 			val inputs = slotIndices.associate { (name, index) ->
-				val id = event.screen.getSlotByIndex(index, false)?.item?.takeIf { !it.isEmpty() }?.let {
+				val id = event.screen.getSlotByIndex(index, false)?.item?.accessor()?.takeIf { !it.isEmpty() }?.let {
 					"${it.skyBlockId?.neuItem}:${it.count}"
 				} ?: ""
 				name to JsonPrimitive(id)
 			}
-			val output = event.screen.getSlotByIndex(resultSlot, false)?.item!!
+			val output = event.screen.getSlotByIndex(resultSlot, false)?.item!!.accessor()
 			val overrideOutputId = output.skyBlockId!!.neuItem
 			val count = output.count
 			val recipe = JsonObject(
@@ -116,7 +118,7 @@ object ExportRecipe {
 				ItemExporter.exportStub(shopId, "§9$title (NPC)", MC.instance.crosshairPickEntity)
 			}
 			for (index in (9..9 * 5)) {
-				val item = event.screen.getSlotByIndex(index, false)?.item ?: continue
+				val item = event.screen.getSlotByIndex(index, false)?.item?.accessor() ?: continue
 				val skyblockId = item.skyBlockId ?: continue
 				val costLines = item.loreAccordingToNbt
 					.map { it.string.trim() }

--- a/src/main/kotlin/features/debug/itemeditor/ItemExporter.kt
+++ b/src/main/kotlin/features/debug/itemeditor/ItemExporter.kt
@@ -41,8 +41,11 @@ import moe.nea.firmament.util.LegacyTagWriter.Companion.toLegacyString
 import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.focusedItemStack
+import moe.nea.firmament.util.mc.LazyItemStack
 import moe.nea.firmament.util.mc.SNbtFormatter.Companion.toPrettyString
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
+import moe.nea.firmament.util.mc.isItem
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.mc.setSkullOwner
 import moe.nea.firmament.util.mc.toNbtList
@@ -54,7 +57,8 @@ import moe.nea.firmament.util.unformattedString
 
 object ItemExporter {
 
-	fun exportItem(itemStack: ItemStack): Component {
+	fun exportItem(itemStack: ItemStack): Component = exportItem(LazyItemStack.fromItemStack(itemStack))
+	fun exportItem(itemStack: LazyItemStack): Component {
 		nonOverlayCache.clear()
 		val exporter = LegacyItemExporter.createExporter(itemStack)
 		var json = exporter.exportJson()
@@ -109,8 +113,8 @@ object ItemExporter {
 		pathFor(skyblockId).exists()
 
 	fun ensureExported(itemStack: ItemStack) {
-		if (!isExported(itemStack.skyBlockId ?: return))
-			MC.sendChat(exportItem(itemStack))
+		if (!isExported(itemStack.accessor().skyBlockId ?: return))
+			MC.sendChat(exportItem(LazyItemStack.fromItemStack(itemStack)))
 	}
 
 	fun modifyJson(skyblockId: SkyblockId, modify: (JsonObject) -> JsonObject) {
@@ -220,9 +224,9 @@ object ItemExporter {
 
 		val itemStack = event.screen.focusedItemStack ?: return
 		val displayName = itemStack.displayName?.string ?: return
-		val skyblockID = itemStack.skyBlockId.toString()
+		val skyblockID = itemStack.accessor().skyBlockId.toString()
 		val vanillaItem = itemStack.item
-		val lore = itemStack.loreAccordingToNbt
+		val lore = itemStack.accessor().loreAccordingToNbt
 
 		val warn = { reason: String ->
 			MC.sendChat(
@@ -258,14 +262,14 @@ object ItemExporter {
 			return
 		}
 		val stack = event.slot.item ?: return
-		val id = event.slot.item.skyBlockId?.neuItem
+		val id = event.slot.item.accessor().skyBlockId?.neuItem
 		if (PowerUserTools.TConfig.dontHighlightSemicolonItems && id != null && id.contains(";")) return
-		val sbId = stack.skyBlockId ?: return
+		val sbId = stack.accessor().skyBlockId ?: return
 		val isExported = nonOverlayCache.getOrPut(sbId) {
 			RepoManager.overlayData.getOverlayFiles(sbId).isNotEmpty() || // This extra case is here so that an export works immediately, without repo reload
 				RepoDownloadManager.repoSavedLocation.resolve("itemsOverlay")
 					.resolve(ExportedTestConstantMeta.current.dataVersion.toString())
-					.resolve("${stack.skyBlockId}.snbt")
+					.resolve("${stack.accessor().skyBlockId}.snbt")
 					.exists()
 		}
 		if (!isExported)
@@ -282,15 +286,15 @@ object ItemExporter {
 	}
 
 	fun exportStub(skyblockId: SkyblockId, title: String, entity: Entity?) {
-		val exportText = exportItem(ItemStack(getItemForEntity(entity)).also {
-			it.displayNameAccordingToNbt = Component.literal(title)
-			it.loreAccordingToNbt = listOf(Component.literal(""))
-			it.setSkyBlockId(skyblockId)
-			if (it.`is`(Items.PLAYER_HEAD)) {
+		val exportText = exportItem(LazyItemStack.build(getItemForEntity(entity)) {
+			displayNameAccordingToNbt = Component.literal(title)
+			loreAccordingToNbt = listOf(Component.literal(""))
+			setSkyBlockId(skyblockId)
+			if (isItem(Items.PLAYER_HEAD)) {
 				val playerEntity = entity as? AbstractClientPlayer
 				val textureUrl = (playerEntity?.skin?.body as? ClientAsset.DownloadedTexture)?.url
 				if (textureUrl != null)
-					it.setSkullOwner(playerEntity.uuid, textureUrl)
+					setSkullOwner(playerEntity.uuid, textureUrl)
 			}
 		})
 		MC.sendChat(exportText)

--- a/src/main/kotlin/features/debug/itemeditor/LegacyItemData.kt
+++ b/src/main/kotlin/features/debug/itemeditor/LegacyItemData.kt
@@ -1,12 +1,17 @@
 package moe.nea.firmament.features.debug.itemeditor
 
 import kotlinx.serialization.Serializable
+import net.minecraft.core.component.DataComponentType
+import net.minecraft.core.component.DataComponents
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.resources.Identifier
+import net.minecraft.resources.ResourceKey
+import net.minecraft.world.item.Item
 import moe.nea.firmament.Firmament
 import moe.nea.firmament.repo.ExpensiveItemCacheApi
 import moe.nea.firmament.repo.ItemCache
 import moe.nea.firmament.util.StringUtil.camelWords
+import moe.nea.firmament.util.mc.FirmamentDataComponentTypes
 import moe.nea.firmament.util.mc.loadItemFromNbt
 
 /**
@@ -59,21 +64,16 @@ object LegacyItemData {
 	val itemDat = getLegacyData<List<ItemData>>("items")
 
 	@OptIn(ExpensiveItemCacheApi::class) // This is fine, we get loaded in a thread.
-	val itemLut = itemDat.flatMap { item ->
+	val itemLut: Map<ResourceKey<Item>, LegacyItemType> = itemDat.flatMap { item ->
 		item.allVariants().map { legacyItemType ->
 			val nbt = ItemCache.convert189ToModern(CompoundTag().apply {
 				putString("id", legacyItemType.name)
-				putInt("count", 1)
-				if(legacyItemType.metadata != 0.toShort()) {
-					val components = CompoundTag().apply {
-						putShort("minecraft:damage", legacyItemType.metadata)
-					}
-
-					put("components", components)
-				}
+				putByte("Count", 1)
+				putShort("Damage", legacyItemType.metadata)
 			})!!
+			nbt.remove("components")
 			val stack = loadItemFromNbt(nbt) ?: error("Could not transform $legacyItemType: $nbt")
-			stack.item to legacyItemType
+			stack.itemId to legacyItemType
 		}
 	}.toMap()
 

--- a/src/main/kotlin/features/debug/itemeditor/LegacyItemExporter.kt
+++ b/src/main/kotlin/features/debug/itemeditor/LegacyItemExporter.kt
@@ -5,9 +5,6 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlin.concurrent.thread
-import kotlin.jvm.optionals.getOrNull
-import net.minecraft.core.component.DataComponentGetter
-import net.minecraft.core.component.DataComponentType
 import net.minecraft.core.component.DataComponents
 import net.minecraft.nbt.ByteTag
 import net.minecraft.nbt.CompoundTag
@@ -17,9 +14,9 @@ import net.minecraft.nbt.NbtOps
 import net.minecraft.nbt.StringTag
 import net.minecraft.nbt.Tag
 import net.minecraft.network.chat.Component
-import net.minecraft.tags.ItemTags
 import net.minecraft.util.Unit
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.ItemStackTemplate
 import net.minecraft.world.item.Items
 import moe.nea.firmament.Firmament
 import moe.nea.firmament.annotations.Subscribe
@@ -34,7 +31,13 @@ import moe.nea.firmament.util.directLiteralStringContent
 import moe.nea.firmament.util.extraAttributes
 import moe.nea.firmament.util.getLegacyFormatString
 import moe.nea.firmament.util.json.toJsonArray
+import moe.nea.firmament.util.mc.LazyItemStack
+import moe.nea.firmament.util.mc.MutableItemTemplate
+import moe.nea.firmament.util.mc.RequiresComponents
+import moe.nea.firmament.util.mc.defaultItemStack
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
+import moe.nea.firmament.util.mc.isEmpty
+import moe.nea.firmament.util.mc.isItem
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.mc.toNbtList
 import moe.nea.firmament.util.modifyExtraAttributes
@@ -43,9 +46,10 @@ import moe.nea.firmament.util.skyblock.Rarity
 import moe.nea.firmament.util.transformEachRecursively
 import moe.nea.firmament.util.unformattedString
 
-class LegacyItemExporter private constructor(var itemStack: ItemStack) {
+@OptIn(RequiresComponents::class)
+class LegacyItemExporter private constructor(var itemStack: MutableItemTemplate) {
 	init {
-		require(!itemStack.isEmpty)
+		require(!itemStack.isEmpty())
 		itemStack.count = 1
 	}
 
@@ -73,7 +77,7 @@ class LegacyItemExporter private constructor(var itemStack: ItemStack) {
 			extraAttribs.putString("id", it.neuItem)
 		}
 		trimLore()
-		itemStack.loreAccordingToNbt = itemStack.item.defaultInstance.loreAccordingToNbt
+		itemStack.loreAccordingToNbt = itemStack.defaultItemStack().get(DataComponents.LORE)!!.lines
 		itemStack.remove(DataComponents.CUSTOM_NAME)
 	}
 
@@ -158,7 +162,7 @@ class LegacyItemExporter private constructor(var itemStack: ItemStack) {
 	}
 
 	private fun copyPotion() {
-		val effects = itemStack.get(DataComponents.POTION_CONTENTS) ?: return
+		val effects = itemStack.getWithDefault(DataComponents.POTION_CONTENTS) ?: return
 		legacyNbt.put("CustomPotionEffects", ListTag().also {
 			effects.allEffects.forEach { effect ->
 				val effectId = effect.effect.unwrapKey().get().identifier().path
@@ -181,19 +185,13 @@ class LegacyItemExporter private constructor(var itemStack: ItemStack) {
 		return compound
 	}
 
-	object NullData : DataComponentGetter {
-		override fun <T : Any> get(type: DataComponentType<out T>): T? {
-			return null
-		}
-	}
-
 	private fun copyColour() {
-		val leatherTint = itemStack.componentsPatch.get(NullData, DataComponents.DYED_COLOR) ?: return
+		val leatherTint = itemStack.getWithDefault(DataComponents.DYED_COLOR) ?: return
 		legacyNbt.getOrPutCompound("display").put("color", IntTag.valueOf(leatherTint.rgb))
 	}
 
 	private fun copyItemModel() {
-		val itemModel = itemStack.get(DataComponents.ITEM_MODEL) ?: return
+		val itemModel = itemStack.getWithDefault(DataComponents.ITEM_MODEL) ?: return
 		legacyNbt.put("ItemModel", StringTag.valueOf(itemModel.toString()))
 	}
 
@@ -205,11 +203,13 @@ class LegacyItemExporter private constructor(var itemStack: ItemStack) {
 	}
 
 	fun exportModernSnbt(): Tag {
-		val overlay = ItemStack.CODEC.encodeStart(MC.currentOrDefaultRegistryNbtOps, itemStack.copy().also {
-			it.modifyExtraAttributes { attribs ->
-				originalId.ifPresent { attribs.putString("id", it) }
-			}
-		}).orThrow
+		val overlay =
+			ItemStack.CODEC.encodeStart(MC.currentOrDefaultRegistryNbtOps, itemStack.finish().withMutations {
+				modifyExtraAttributes { attribs ->
+					originalId.ifPresent { attribs.putString("id", it) }
+					collapseDefaults()
+				}
+			}.upgrade()).orThrow
 		val overlayWithVersion =
 			ExportedTestConstantMeta.SOURCE_CODEC.encode(ExportedTestConstantMeta.current, NbtOps.INSTANCE, overlay)
 				.orThrow
@@ -244,8 +244,8 @@ class LegacyItemExporter private constructor(var itemStack: ItemStack) {
 	}
 
 	companion object {
-		fun createExporter(itemStack: ItemStack): LegacyItemExporter {
-			return LegacyItemExporter(itemStack.copy()).also { it.prepare() }
+		fun createExporter(itemStack: LazyItemStack): LegacyItemExporter {
+			return LegacyItemExporter(itemStack.intoMutable()).also { it.prepare() }
 		}
 
 		@Subscribe
@@ -316,8 +316,8 @@ class LegacyItemExporter private constructor(var itemStack: ItemStack) {
 	}
 
 	fun legacyifyItemStack(): LegacyItemData.LegacyItemType {
-		if (itemStack.item == Items.LINGERING_POTION || itemStack.item == Items.SPLASH_POTION)
+		if (itemStack.isItem(Items.LINGERING_POTION) || itemStack.isItem(Items.SPLASH_POTION))
 			return LegacyItemData.LegacyItemType("potion", 16384)
-		return LegacyItemData.itemLut[itemStack.item] ?: LegacyItemData.LegacyItemType(itemStack.item.toString(), 0)
+		return LegacyItemData.itemLut[itemStack.itemId] ?: LegacyItemData.LegacyItemType(itemStack.item.registeredName, 0)
 	}
 }

--- a/src/main/kotlin/features/diana/AncestralSpadeSolver.kt
+++ b/src/main/kotlin/features/diana/AncestralSpadeSolver.kt
@@ -15,6 +15,7 @@ import moe.nea.firmament.util.SBData
 import moe.nea.firmament.util.SkyBlockIsland
 import moe.nea.firmament.util.TimeMark
 import moe.nea.firmament.util.WarpUtil
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.render.RenderInWorldContext
 import moe.nea.firmament.util.skyBlockId
 import moe.nea.firmament.util.skyblock.SkyBlockItems
@@ -33,10 +34,11 @@ object AncestralSpadeSolver {
 		DianaWaypoints.TConfig.ancestralSpadeSolver
 			&& SBData.skyblockLocation == SkyBlockIsland.HUB
 			&& MC.player?.inventory?.hasAnyMatching {
-				it.skyBlockId == SkyBlockItems.ANCESTRAL_SPADE ||
-					it.skyBlockId == SkyBlockItems.ARCHAIC_SPADE ||
-					it.skyBlockId == SkyBlockItems.DEIFIC_SPADE
-			} == true // TODO: add a reactive property here
+			val skyBlockId = it.accessor().skyBlockId
+			skyBlockId == SkyBlockItems.ANCESTRAL_SPADE ||
+				skyBlockId == SkyBlockItems.ARCHAIC_SPADE ||
+				skyBlockId == SkyBlockItems.DEIFIC_SPADE
+		} == true // TODO: add a reactive property here
 
 	@Subscribe
 	fun onKeyBind(event: WorldKeyboardEvent) {

--- a/src/main/kotlin/features/events/anniversity/AnniversaryFeatures.kt
+++ b/src/main/kotlin/features/events/anniversity/AnniversaryFeatures.kt
@@ -22,7 +22,9 @@ import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.TimeMark
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
+import moe.nea.firmament.util.mc.RequiresComponents
 import moe.nea.firmament.util.parseShortNumber
+import moe.nea.firmament.util.renderingName
 import moe.nea.firmament.util.useMatch
 
 object AnniversaryFeatures {
@@ -201,13 +203,13 @@ object AnniversaryFeatures {
 				SBItemStack(SkyblockId.NULL)
 			}
 
-			@OptIn(ExpensiveItemCacheApi::class)
+			@OptIn(ExpensiveItemCacheApi::class, RequiresComponents::class)
 			@Bind
 			fun name(): Component {
 				return when (backedBy) {
 					is Reward.Coins -> Component.literal("Coins")
 					is Reward.EXP -> Component.literal(backedBy.skill)
-					is Reward.Items -> itemStack.asImmutableItemStack().hoverName
+					is Reward.Items -> itemStack.asImmutableItemStack().renderingName
 					is Reward.Unknown -> Component.literal(backedBy.text)
 				}
 			}

--- a/src/main/kotlin/features/events/anniversity/CenturyRaffleFeatures.kt
+++ b/src/main/kotlin/features/events/anniversity/CenturyRaffleFeatures.kt
@@ -12,6 +12,7 @@ import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.render.TintedOverlayTexture
 import moe.nea.firmament.util.skyBlockId
 import moe.nea.firmament.util.skyblock.SkyBlockItems
@@ -49,7 +50,7 @@ object CenturyRaffleFeatures {
 	@Subscribe
 	fun onEntityRender(event: EntityRenderTintEvent) {
 		if (!TConfig.highlightPlayersForSlice) return
-		val requestedCakeTeam = sliceToColor[MC.stackInHand?.skyBlockId] ?: return
+		val requestedCakeTeam = sliceToColor[MC.stackInHand.accessor().skyBlockId] ?: return
 		// TODO: cache the requested color
 		val player = event.entity as? Player ?: return
 		val cakeColor: Style = player.feedbackDisplayName.visit(

--- a/src/main/kotlin/features/events/carnival/MinesweeperHelper.kt
+++ b/src/main/kotlin/features/events/carnival/MinesweeperHelper.kt
@@ -27,6 +27,8 @@ import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.MoulConfigUtils
 import moe.nea.firmament.util.ScreenUtil
 import moe.nea.firmament.util.SkyblockId
+import moe.nea.firmament.util.mc.RequiresComponents
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.createSkullItem
 import moe.nea.firmament.util.render.RenderInWorldContext
 import moe.nea.firmament.util.setSkyBlockFirmamentUiId
@@ -44,7 +46,7 @@ object MinesweeperHelper {
     val startGameQuestion = "[NPC] Carnival Pirateman: Would ye like to do some Fruit Digging?"
 
 
-    enum class Piece(
+	enum class Piece(
         val fruitName: String,
         val points: Int,
         val specialAbility: String,
@@ -116,12 +118,13 @@ object MinesweeperHelper {
 
         val textureUrl = "http://textures.minecraft.net/texture/$textureHash"
         val itemStack = createSkullItem(UUID.randomUUID(), textureUrl)
-            .setSkyBlockFirmamentUiId("MINESWEEPER_$name")
+			.withMutations { setSkyBlockFirmamentUiId("MINESWEEPER_$name") }
 		@get:Bind("fruitName")
 		val textFruitName = Component.literal(fruitName)
 
         @Bind
-        fun getIcon() = MoulConfigPlatform.wrap(itemStack)
+		@OptIn(RequiresComponents::class)
+        fun getIcon() = MoulConfigPlatform.wrap(itemStack.upgrade())
 
         @get:Bind("pieceLabel")
         val pieceLabel = Component.literal(fruitColor.formattingCode + fruitName)
@@ -164,7 +167,7 @@ object MinesweeperHelper {
         companion object {
             val id = SkyblockId("CARNIVAL_SHOVEL")
             fun fromItem(itemStack: ItemStack): DowsingMode? {
-                if (itemStack.skyBlockId != id) return null
+                if (itemStack.accessor().skyBlockId != id) return null
                 return DowsingMode.entries.find { it.itemType == itemStack.item }
             }
         }

--- a/src/main/kotlin/features/inventory/CraftingOverlay.kt
+++ b/src/main/kotlin/features/inventory/CraftingOverlay.kt
@@ -10,6 +10,7 @@ import moe.nea.firmament.events.SlotRenderEvents
 import moe.nea.firmament.repo.ExpensiveItemCacheApi
 import moe.nea.firmament.repo.SBItemStack
 import moe.nea.firmament.util.MC
+import moe.nea.firmament.util.mc.RequiresComponents
 import moe.nea.firmament.util.skyblockId
 
 object CraftingOverlay {
@@ -45,7 +46,7 @@ object CraftingOverlay {
 	val identifier: String
 		get() = "crafting-overlay"
 
-	@OptIn(ExpensiveItemCacheApi::class)
+	@OptIn(ExpensiveItemCacheApi::class, RequiresComponents::class)
 	@Subscribe
 	fun onSlotRender(event: SlotRenderEvents.After) {
 		val slot = event.slot
@@ -69,10 +70,10 @@ object CraftingOverlay {
 		}
 		if (!slot.hasItem()) {
 			val itemStack = SBItemStack(expectedItem)?.asImmutableItemStack() ?: return
-			event.context.item(itemStack, event.slot.x, event.slot.y)
+			event.context.item(itemStack.upgrade(), event.slot.x, event.slot.y)
 			event.context.itemDecorations(
 				MC.font,
-				itemStack,
+				itemStack.upgrade(),
 				event.slot.x,
 				event.slot.y,
 				"${ChatFormatting.RED}${expectedItem.amount.toInt()}"

--- a/src/main/kotlin/features/inventory/ItemHotkeys.kt
+++ b/src/main/kotlin/features/inventory/ItemHotkeys.kt
@@ -12,6 +12,10 @@ import moe.nea.firmament.util.asBazaarStock
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
 import moe.nea.firmament.util.focusedItemStack
+import moe.nea.firmament.util.mc.LazyItemStack
+import moe.nea.firmament.util.mc.RequiresComponents
+import moe.nea.firmament.util.mc.accessor
+import moe.nea.firmament.util.mc.lazy
 import moe.nea.firmament.util.skyBlockId
 import moe.nea.firmament.util.skyblock.SBItemUtil.getSearchName
 
@@ -21,13 +25,13 @@ object ItemHotkeys {
 		val openGlobalTradeInterface by keyBindingWithDefaultUnbound("global-trade-interface")
 	}
 
-	@OptIn(ExpensiveItemCacheApi::class)
+	@OptIn(ExpensiveItemCacheApi::class, RequiresComponents::class)
 	@Subscribe
 	fun onHandledInventoryPress(event: HandledScreenKeyPressedEvent) {
 		if (!event.matches(TConfig.openGlobalTradeInterface)) {
 			return
 		}
-		var item = event.screen.focusedItemStack ?: return
+		var item = event.screen.focusedItemStack?.lazy() ?: return
 		val skyblockId = item.skyBlockId ?: return
 		item = RepoManager.getNEUItem(skyblockId)?.asItemStack()?.takeIf { !it.isBroken } ?: item
 		if (HypixelStaticData.hasBazaarStock(skyblockId.asBazaarStock)) {

--- a/src/main/kotlin/features/inventory/ItemRarityCosmetics.kt
+++ b/src/main/kotlin/features/inventory/ItemRarityCosmetics.kt
@@ -10,6 +10,7 @@ import moe.nea.firmament.events.HotbarItemRenderEvent
 import moe.nea.firmament.events.SlotRenderEvents
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.skyblock.Rarity
 
 object ItemRarityCosmetics {
@@ -28,7 +29,7 @@ object ItemRarityCosmetics {
 	}
 
 	fun drawItemStackRarity(drawContext: GuiGraphicsExtractor, x: Int, y: Int, item: ItemStack) {
-		val rarity = Rarity.fromItem(item) ?: return
+		val rarity = Rarity.fromItem(item.accessor()) ?: return
 		val rgb = rarityToColor[rarity] ?: 0xFF00FF80.toInt()
 		drawContext.blitSprite(
 			RenderPipelines.GUI_TEXTURED,

--- a/src/main/kotlin/features/inventory/JunkHighlighter.kt
+++ b/src/main/kotlin/features/inventory/JunkHighlighter.kt
@@ -5,6 +5,8 @@ import moe.nea.firmament.annotations.Subscribe
 import moe.nea.firmament.events.SlotRenderEvents
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
+import moe.nea.firmament.util.mc.RequiresComponents
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.skyblock.SBItemUtil.getSearchName
 import moe.nea.firmament.util.useMatch
 
@@ -18,12 +20,13 @@ object JunkHighlighter {
 		val highlightBind by keyBinding("highlight") { GLFW.GLFW_KEY_LEFT_CONTROL }
 	}
 
+	@OptIn(RequiresComponents::class)
 	@Subscribe
 	fun onDrawSlot(event: SlotRenderEvents.After) {
 		if (!TConfig.highlightBind.isPressed() || TConfig.junkRegex.isEmpty()) return
 		val junkRegex = TConfig.junkRegex.toPattern()
 		val slot = event.slot
-		junkRegex.useMatch(slot.item.getSearchName()) {
+		junkRegex.useMatch(slot.item.accessor().getSearchName()) {
 			event.context.fill(slot.x, slot.y, slot.x + 16, slot.y + 16, 0xffff0000.toInt())
 		}
 	}

--- a/src/main/kotlin/features/inventory/MissingEnchantments.kt
+++ b/src/main/kotlin/features/inventory/MissingEnchantments.kt
@@ -19,6 +19,7 @@ import moe.nea.firmament.util.removeColorCodes
 import moe.nea.firmament.util.unformattedString
 import moe.nea.firmament.util.IntUtil.toRomanNumeral
 import moe.nea.firmament.util.grey
+import moe.nea.firmament.util.mc.accessor
 
 object MissingEnchantments {
 	fun itemTypeToEnchantKey(itemType: ItemType): String {
@@ -51,12 +52,12 @@ object MissingEnchantments {
 		if (!TConfig.enabled) return
 		if (TConfig.enableKeybinding.isBound && !TConfig.enableKeybinding.isPressed()) return
 
-		val itemType = ItemType.fromItemStack(it.stack)
+		val itemType = ItemType.fromItemStack(it.stack.accessor())
 		val pools = RepoManager.enchantData.allEnchants?.enchantPools
 		val maxLevels: Map<String, Int> =
 			RepoManager.enchantData.allEnchants?.enchantExperienceCost?.mapValues { it.value.size }?: emptyMap()
 
-		val appliedEnchantmentsData = it.stack.extraAttributes.getCompound("enchantments").getOrNull()
+		val appliedEnchantmentsData = it.stack.accessor().extraAttributes.getCompound("enchantments").getOrNull()
 		val appliedEnchantments = appliedEnchantmentsData?.keySet().orEmpty()
 		val appliedEnchantmentLevels = appliedEnchantmentsData?.keySet()?.associateWith { enchId -> appliedEnchantmentsData.getInt(enchId) }
 		val enchantKey = itemType?.let { itemTypeToEnchantKey(it) } ?: return

--- a/src/main/kotlin/features/inventory/PetFeatures.kt
+++ b/src/main/kotlin/features/inventory/PetFeatures.kt
@@ -27,6 +27,11 @@ import moe.nea.firmament.util.SkyBlockIsland
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
 import moe.nea.firmament.util.formattedString
+import moe.nea.firmament.util.mc.DataComponentAccessor
+import moe.nea.firmament.util.mc.LazyItemStack
+import moe.nea.firmament.util.mc.RequiresComponents
+import moe.nea.firmament.util.mc.accessor
+import moe.nea.firmament.util.mc.lazy
 import moe.nea.firmament.util.parseShortNumber
 import moe.nea.firmament.util.petData
 import moe.nea.firmament.util.render.drawGuiTexture
@@ -87,9 +92,9 @@ object PetFeatures {
 		// Cache pets
 		petMenuTitle.useMatch(MC.screenName ?: return) {
 			val stack = event.slot.item
-			if (!stack.isEmpty) cachePet(stack)
-			if (stack.petData?.active == true) {
-				if (currentPetUUID == "") currentPetUUID = stack.skyblockUUID.toString()
+			if (!stack.isEmpty) cachePet(stack.lazy())
+			if (stack.accessor().petData?.active == true) {
+				if (currentPetUUID == "") currentPetUUID = stack.accessor().skyblockUUID.toString()
 				// Highlight active pet feature
 				if (!TConfig.highlightEquippedPet) return
 				event.context.drawGuiTexture(
@@ -100,7 +105,7 @@ object PetFeatures {
 		}
 	}
 
-	private fun cachePet(stack: ItemStack) {
+	private fun cachePet(stack: LazyItemStack) {
 		// Cache information about a pet
 		if (stack.skyblockUUID == null) return
 		if (petMap.containsKey(stack.skyblockUUID.toString()) &&
@@ -116,14 +121,14 @@ object PetFeatures {
 		petMenuTitle.useMatch(MC.screenName ?: return) {
 			if (event.slot.container is Inventory) return
 			if (event.button != 0 && event.button != 1) return
-			val petData = event.stack.petData ?: return
+			val petData = event.stack.accessor().petData ?: return
 			if (petData.active == true) {
 				currentPetUUID = "None"
 				return
 			}
 			if (event.button != 0) return
-			if (!petMap.containsKey(event.stack.skyblockUUID.toString())) cachePet(event.stack)
-			currentPetUUID = event.stack.skyblockUUID.toString()
+			if (!petMap.containsKey(event.stack.accessor().skyblockUUID.toString())) cachePet(event.stack.lazy())
+			currentPetUUID = event.stack.accessor().skyblockUUID.toString()
 		}
 	}
 
@@ -198,6 +203,7 @@ object PetFeatures {
 		}
 	}
 
+	@OptIn(RequiresComponents::class)
 	@Subscribe
 	fun onRenderHud(it: HudRenderEvent) {
 		if (!TConfig.petOverlay || !SBData.isOnSkyblock) return
@@ -336,7 +342,7 @@ object PetFeatures {
 		it.context.pose().pushMatrix()
 		it.context.pose().translate(-0.5F, -0.5F)
 		it.context.pose().scale(2f, 2f)
-		it.context.item(pet.petItemStack.value, 0, 0)
+		it.context.item(pet.petItemStack.value.upgrade(), 0, 0)
 		it.context.pose().popMatrix()
 
 		it.context.pose().popMatrix()
@@ -497,7 +503,7 @@ object PetParser {
 		)
 	}
 
-	fun parsePetMenuSlot(stack: ItemStack) : ParsedPet? {
+	fun parsePetMenuSlot(stack: LazyItemStack) : ParsedPet? {
 		val petData = stack.petData ?: return null
 		val expData = petData.level
 		val overflow = if (expData.expTotal - expData.expRequiredForMaxLevel > 0)
@@ -524,20 +530,20 @@ object PetParser {
 }
 
 data class ParsedPet(
-    val name: String,
-    val rarity: Rarity,
-    var level: Int,
-    val maxLevel: Int,
-    val expLadder: ExpLadders.ExpLadder?,
-    var currentExp: Double,
-    var expForNextLevel: Double,
-    var totalExp: Double,
-    var totalExpBeforeLevel: Double,
-    val expForMax: Double,
-    var overflowExp: Double,
-    var petItem: String,
-    var petItemStack: Lazy<ItemStack>,
-    var isComplete: Boolean
+	val name: String,
+	val rarity: Rarity,
+	var level: Int,
+	val maxLevel: Int,
+	val expLadder: ExpLadders.ExpLadder?,
+	var currentExp: Double,
+	var expForNextLevel: Double,
+	var totalExp: Double,
+	var totalExpBeforeLevel: Double,
+	val expForMax: Double,
+	var overflowExp: Double,
+	var petItem: String,
+	var petItemStack: Lazy<LazyItemStack>,
+	var isComplete: Boolean
 ) {
 	fun update(other: ParsedPet) {
 		// Update the pet data to reflect another instance (of itself)

--- a/src/main/kotlin/features/inventory/PriceData.kt
+++ b/src/main/kotlin/features/inventory/PriceData.kt
@@ -14,6 +14,7 @@ import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
 import moe.nea.firmament.util.getLogicalStackSize
 import moe.nea.firmament.util.gold
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.skyBlockId
 import moe.nea.firmament.util.tr
 import moe.nea.firmament.util.yellow
@@ -77,8 +78,8 @@ object PriceData {
 	fun onItemTooltip(it: ItemTooltipEvent) {
 		if (!TConfig.tooltipEnabled) return
 		if (TConfig.enableKeybinding.isBound && !TConfig.enableKeybinding.isPressed()) return
-		val sbId = it.stack.skyBlockId
-		val stackSize = it.stack.getLogicalStackSize()
+		val sbId = it.stack.accessor().skyBlockId
+		val stackSize = it.stack.accessor().getLogicalStackSize()
 		val isShowingStack = TConfig.stackSizeKey.isPressed()
 		val multiplier = if (isShowingStack) stackSize else 1
 		val multiplierText =

--- a/src/main/kotlin/features/inventory/SlotLocking.kt
+++ b/src/main/kotlin/features/inventory/SlotLocking.kt
@@ -49,9 +49,12 @@ import moe.nea.firmament.util.data.ProfileSpecificDataHolder
 import moe.nea.firmament.util.extraAttributes
 import moe.nea.firmament.util.json.DashlessUUIDSerializer
 import moe.nea.firmament.util.lime
+import moe.nea.firmament.util.mc.DataComponentAccessor
 import moe.nea.firmament.util.mc.ScreenUtil.getSlotByIndex
 import moe.nea.firmament.util.mc.SlotUtils.swapWithHotBar
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
+import moe.nea.firmament.util.mc.isEmpty
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.red
 import moe.nea.firmament.util.render.drawAlignedBox
@@ -188,8 +191,8 @@ object SlotLocking {
 		val handler = screen.menu as? ChestMenu ?: return false
 		if (handler.container.containerSize < 9) return false
 		val middlePane = handler.container.getItem(handler.container.containerSize - 5)
-		if (middlePane == null) return false
-		return middlePane.displayNameAccordingToNbt?.unformattedString == "⇦ Your stuff"
+		if (middlePane.isEmpty) return false
+		return middlePane.accessor().displayNameAccordingToNbt.unformattedString == "⇦ Your stuff"
 	}
 
 	fun isNpcShop(screen: AbstractContainerScreen<*>?): Boolean {
@@ -197,9 +200,9 @@ object SlotLocking {
 		val handler = screen.menu as? ChestMenu ?: return false
 		if (handler.container.containerSize < 9) return false
 		val sellItem = handler.container.getItem(handler.container.containerSize - 5)
-		if (sellItem == null) return false
-		if (sellItem.displayNameAccordingToNbt.unformattedString == "Sell Item") return true
-		val lore = sellItem.loreAccordingToNbt
+		if (sellItem.isEmpty) return false
+		if (sellItem.accessor().displayNameAccordingToNbt.unformattedString == "Sell Item") return true
+		val lore = sellItem.accessor().loreAccordingToNbt
 		return (lore.lastOrNull() ?: return false).unformattedString == "Click to buyback!"
 	}
 
@@ -207,7 +210,7 @@ object SlotLocking {
 	fun onSalvageProtect(event: IsSlotProtectedEvent) {
 		if (event.slot == null) return
 		if (!event.slot.hasItem()) return
-		if (event.slot.item.displayNameAccordingToNbt.unformattedString != "Salvage Items") return
+		if (event.slot.item.accessor().displayNameAccordingToNbt.unformattedString != "Salvage Items") return
 		val inv = event.slot.container
 		var anyBlocked = false
 		for (i in 0 until event.slot.containerSlot) {
@@ -239,7 +242,8 @@ object SlotLocking {
 		if ((!isSellOrTradeScreen || event.slot?.container !is Inventory)
 			&& doesNotDeleteItem
 		) return
-		val stack = event.itemStack ?: return
+		val stack = event.itemStack.accessor()
+		if (stack.isEmpty()) return
 		if (TConfig.protectAllHuntingBoxes && (stack.isHuntingBox())) {
 			event.protect()
 			return
@@ -250,7 +254,7 @@ object SlotLocking {
 		}
 	}
 
-	fun ItemStack.isHuntingBox(): Boolean {
+	fun DataComponentAccessor.isHuntingBox(): Boolean {
 		return skyBlockId == SkyBlockItems.HUNTING_TOOLKIT || extraAttributes.get("tool_kit") != null
 	}
 
@@ -308,7 +312,7 @@ object SlotLocking {
 		inventory.castAccessor()
 
 		val slot = inventory.focusedSlot_Firmament ?: return
-		val stack = slot.item ?: return
+		val stack = slot.item.accessor().takeUnless { it.isEmpty() } ?: return
 		if (stack.isHuntingBox()) {
 			MC.sendChat(
 				tr(
@@ -510,7 +514,7 @@ object SlotLocking {
 	@Subscribe
 	fun onRenderSlotOverlay(it: SlotRenderEvents.After) {
 		val isSlotLocked = it.slot.container is Inventory && it.slot.containerSlot in (lockedSlots ?: setOf())
-		val isUUIDLocked = (it.slot.item?.skyblockUUID) in (lockedUUIDs ?: setOf())
+		val isUUIDLocked = (it.slot.item.accessor().skyblockUUID) in (lockedUUIDs ?: setOf())
 		if (isSlotLocked || isUUIDLocked) {
 			it.context.blitSprite(
 				RenderPipelines.GUI_TEXTURED,

--- a/src/main/kotlin/features/inventory/TimerInLore.kt
+++ b/src/main/kotlin/features/inventory/TimerInLore.kt
@@ -16,6 +16,7 @@ import moe.nea.firmament.util.aqua
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
 import moe.nea.firmament.util.grey
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.timestamp
 import moe.nea.firmament.util.tr
@@ -104,7 +105,7 @@ object TimerInLore {
 	@Subscribe
 	fun creationInLore(event: ItemTooltipEvent) {
 		if (!TConfig.showCreationTimestamp) return
-		val timestamp = event.stack.timestamp ?: return
+		val timestamp = event.stack.accessor().timestamp ?: return
 		val formattedTimestamp = TConfig.timerFormat.formatter.format(ZonedDateTime.ofInstant(timestamp, ZoneId.systemDefault()))
 		event.lines.add(tr("firmament.lore.creationtimestamp", "Created at: $formattedTimestamp").grey())
 	}
@@ -117,7 +118,7 @@ object TimerInLore {
 			val line = event.lines[i].unformattedString
 			val countdownType = CountdownTypes.entries.find { it.match in line } ?: continue
 			if (countdownType == CountdownTypes.CALENDARDETAILS
-				&& !event.stack.displayNameAccordingToNbt.unformattedString.startsWith("Day ")
+				&& !event.stack.accessor().displayNameAccordingToNbt.unformattedString.startsWith("Day ")
 			) continue
 
 			val countdownMatch = regex.findAll(line).filter { it.value.isNotBlank() }.lastOrNull() ?: continue

--- a/src/main/kotlin/features/inventory/buttons/InventoryButton.kt
+++ b/src/main/kotlin/features/inventory/buttons/InventoryButton.kt
@@ -21,8 +21,11 @@ import moe.nea.firmament.util.ErrorUtil
 import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.collections.memoize
+import moe.nea.firmament.util.mc.LazyItemStack
+import moe.nea.firmament.util.mc.RequiresComponents
 import moe.nea.firmament.util.mc.arbitraryUUID
 import moe.nea.firmament.util.mc.createSkullItem
+import moe.nea.firmament.util.mc.lazy
 import moe.nea.firmament.util.render.drawGuiTexture
 
 @Serializable
@@ -54,7 +57,7 @@ data class InventoryButton(
 
 
 
-		fun getCustomItem0(icon: String): ItemStack? {
+		fun getCustomItem0(icon: String): LazyItemStack? {
 			when {
 				icon.startsWith("skull:") -> {
 					return createSkullItem(
@@ -71,13 +74,13 @@ data class InventoryButton(
 						runCatching {
 							itemStackParser.parse(StringReader(giveSyntaxItem)).createItemStack(1)
 						}.getOrNull()
-					return componentItem
+					return componentItem?.lazy()
 				}
 			}
 		}
 
 		@OptIn(ExpensiveItemCacheApi::class)
-		fun getItemForName(icon: String): ItemStack {
+		fun getItemForName(icon: String): LazyItemStack {
 			val repoItem = RepoManager.getNEUItem(SkyblockId(icon))
 			var itemStack = repoItem.asItemStack(idHint = SkyblockId(icon))
 			if (repoItem == null) {
@@ -89,6 +92,7 @@ data class InventoryButton(
 		}
 	}
 
+	@OptIn(RequiresComponents::class)
 	fun render(context: GuiGraphicsExtractor) {
 		context.blitSprite(
 			RenderPipelines.GUI_TEXTURED,
@@ -102,10 +106,10 @@ data class InventoryButton(
 			context.pose().pushMatrix()
 			context.pose().translate(myDimension.width / 2F, myDimension.height / 2F)
 			context.pose().scale(2F)
-			context.item(getItem(), -8, -8)
+			context.item(getItem().upgrade(), -8, -8)
 			context.pose().popMatrix()
 		} else {
-			context.item(getItem(), 1, 1)
+			context.item(getItem().upgrade(), 1, 1)
 		}
 	}
 
@@ -122,7 +126,7 @@ data class InventoryButton(
 		return Rectangle(getPosition(guiRect), myDimension)
 	}
 
-	fun getItem(): ItemStack {
+	fun getItem(): LazyItemStack {
 		return getItemForName(icon ?: "")
 	}
 

--- a/src/main/kotlin/features/inventory/buttons/InventoryButtonEditor.kt
+++ b/src/main/kotlin/features/inventory/buttons/InventoryButtonEditor.kt
@@ -23,6 +23,7 @@ import moe.nea.firmament.util.ClipboardUtils
 import moe.nea.firmament.util.FragmentGuiScreen
 import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.MoulConfigUtils
+import moe.nea.firmament.util.mc.RequiresComponents
 import moe.nea.firmament.util.tr
 
 class InventoryButtonEditor(
@@ -38,10 +39,11 @@ class InventoryButtonEditor(
 		@field:Bind
 		var isGigantic: Boolean = originalButton.isGigantic
 
+		@OptIn(RequiresComponents::class)
 		@Bind
 		fun getItemIcon(): IItemStack {
 			save()
-			return MoulConfigPlatform.wrap(InventoryButton.getItemForName(icon))
+			return MoulConfigPlatform.wrap(InventoryButton.getItemForName(icon).upgrade())
 		}
 
 		@Bind

--- a/src/main/kotlin/features/inventory/storageoverlay/StorageOverlayScreen.kt
+++ b/src/main/kotlin/features/inventory/storageoverlay/StorageOverlayScreen.kt
@@ -40,6 +40,7 @@ import moe.nea.firmament.util.assertTrueOr
 import moe.nea.firmament.util.customgui.customGui
 import moe.nea.firmament.util.mc.FakeSlot
 import moe.nea.firmament.util.mc.RequiresComponents
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.render.drawAlignedBox
@@ -451,9 +452,9 @@ class StorageOverlayScreen : Screen(Component.literal("")) {
 		fun removePrefixes(value: String) {
 			searchWords.removeIf { value.contains(it, ignoreCase = true) }
 		}
-		itemStack.displayNameAccordingToNbt.unformattedString.words().forEach(::removePrefixes)
+		itemStack.accessor().displayNameAccordingToNbt.unformattedString.words().forEach(::removePrefixes)
 		if (searchWords.isEmpty()) return true
-		itemStack.loreAccordingToNbt.forEach {
+		itemStack.accessor().loreAccordingToNbt.forEach {
 			it.unformattedString.words().forEach(::removePrefixes)
 		}
 		return searchWords.isEmpty()

--- a/src/main/kotlin/features/items/BlockZapperOverlay.kt
+++ b/src/main/kotlin/features/items/BlockZapperOverlay.kt
@@ -14,6 +14,7 @@ import moe.nea.firmament.events.WorldRenderLastEvent
 import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.render.RenderInWorldContext
 import moe.nea.firmament.util.skyBlockId
 import moe.nea.firmament.util.skyblock.SkyBlockItems
@@ -66,7 +67,7 @@ object BlockZapperOverlay {
 		val player = MC.player ?: return
 		val world = player.level ?: return
 		val heldItem = MC.stackInHand
-		if (heldItem.skyBlockId != SkyBlockItems.BLOCK_ZAPPER) return
+		if (heldItem.accessor().skyBlockId != SkyBlockItems.BLOCK_ZAPPER) return
 		val hitResult = MC.instance.hitResult ?: return
 
 		val zapperBlocks: HashSet<BlockPos> = HashSet()
@@ -133,7 +134,7 @@ object BlockZapperOverlay {
 	fun onWorldKeyboard(it: WorldKeyboardEvent) {
 		if (!TConfig.undoKey.isBound) return
 		if (!it.matches(TConfig.undoKey)) return
-		if (MC.stackInHand.skyBlockId != SkyBlockItems.BLOCK_ZAPPER) return
+		if (MC.stackInHand.accessor().skyBlockId != SkyBlockItems.BLOCK_ZAPPER) return
 		MC.sendCommand("undozap")
 	}
 }

--- a/src/main/kotlin/features/items/BonemerangOverlay.kt
+++ b/src/main/kotlin/features/items/BonemerangOverlay.kt
@@ -13,6 +13,7 @@ import moe.nea.firmament.events.HudRenderEvent
 import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.render.TintedOverlayTexture
 import moe.nea.firmament.util.skyBlockId
 import moe.nea.firmament.util.skyblock.SkyBlockItems
@@ -59,7 +60,7 @@ object BonemerangOverlay {
 	@Subscribe
 	fun onEntityRender(event: EntityRenderTintEvent) {
 		if (!TConfig.highlightHitEntities) return
-		if (MC.stackInHand.skyBlockId !in throwableWeapons) return
+		if (MC.stackInHand.accessor().skyBlockId !in throwableWeapons) return
 
 		val entities = getEntities()
 		if (entities.isEmpty()) return
@@ -76,7 +77,7 @@ object BonemerangOverlay {
 	@Subscribe
 	fun onRenderHud(it: HudRenderEvent) {
 		if (!TConfig.bonemerangOverlay) return
-		if (MC.stackInHand.skyBlockId !in throwableWeapons) return
+		if (MC.stackInHand.accessor().skyBlockId !in throwableWeapons) return
 
 		val entities = getEntities()
 

--- a/src/main/kotlin/features/items/EtherwarpOverlay.kt
+++ b/src/main/kotlin/features/items/EtherwarpOverlay.kt
@@ -18,6 +18,7 @@ import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
 import moe.nea.firmament.util.extraAttributes
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.render.RenderInWorldContext
 import moe.nea.firmament.util.skyBlockId
 import moe.nea.firmament.util.skyblock.SkyBlockItems
@@ -179,7 +180,7 @@ object EtherwarpOverlay {
 		if (TConfig.onlyShowWhileSneaking && !player.isShiftKeyDown) return
 
 		val heldItem = MC.stackInHand
-		if (!heldItem.extraAttributes.contains("ethermerge") && heldItem.skyBlockId != SkyBlockItems.ETHERWARP_CONDUIT) return
+		if (!heldItem.accessor().extraAttributes.contains("ethermerge") && heldItem.accessor().skyBlockId != SkyBlockItems.ETHERWARP_CONDUIT) return
 
 		val world = player.level
 		val start = player.eyePosition

--- a/src/main/kotlin/features/items/recipes/ItemList.kt
+++ b/src/main/kotlin/features/items/recipes/ItemList.kt
@@ -25,6 +25,7 @@ import moe.nea.firmament.repo.RepoManager
 import moe.nea.firmament.repo.SBItemStack
 import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.accessors.castAccessor
+import moe.nea.firmament.util.mc.RequiresComponents
 import moe.nea.firmament.util.render.drawAlignedBox
 import moe.nea.firmament.util.skyblockId
 
@@ -236,6 +237,7 @@ object ItemList {
 
 	var listElements = listOf<ItemListElement>()
 
+	@OptIn(RequiresComponents::class)
 	@Subscribe
 	fun onRender(event: HandledScreenForegroundEvent) {
 		if(!isItemListEnabled) return
@@ -254,7 +256,7 @@ object ItemList {
 		val isPopupHovered = popupElement?.isMouseOver(event.mouseX.toDouble(),event.mouseY.toDouble())
 			?: false
 		lastRenderPositions.forEach { (pos, stack) ->
-			val realStack = stack.asLazyImmutableItemStack()
+			val realStack = stack.asLazyImmutableItemStack()?.upgrade()
 			val toRender = realStack ?: ItemStack(Items.PAINTING)
 			event.context.item(toRender, pos.left() + 1, pos.top() + 1)
 			if (!isPopupHovered && pos.containsPoint(event.mouseX, event.mouseY)) {

--- a/src/main/kotlin/features/items/recipes/ItemSlotWidget.kt
+++ b/src/main/kotlin/features/items/recipes/ItemSlotWidget.kt
@@ -20,7 +20,10 @@ import moe.nea.firmament.util.ErrorUtil
 import moe.nea.firmament.util.FirmFormatters.shortFormat
 import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.darkGrey
+import moe.nea.firmament.util.mc.RequiresComponents
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
+import moe.nea.firmament.util.mc.isEmpty
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 
 class ItemSlotWidget(
@@ -44,7 +47,7 @@ class ItemSlotWidget(
 	override val rect: Rectangle
 		get() = Rectangle(backgroundTopLeft, backgroundSize)
 
-	@OptIn(ExpensiveItemCacheApi::class)
+	@OptIn(ExpensiveItemCacheApi::class, RequiresComponents::class)
 	override fun extractRenderState(
 		context: GuiGraphicsExtractor,
 		mouseX: Int,
@@ -53,17 +56,17 @@ class ItemSlotWidget(
 	) {
 		val stack = current().asImmutableItemStack()
 		// TODO: draw slot background
-		if (stack.isEmpty) return
-		context.item(stack, position.x, position.y)
+		if (stack.isEmpty()) return
+		context.item(stack.upgrade(), position.x, position.y)
 		context.itemDecorations(
-			MC.font, stack, position.x, position.y,
+			MC.font, stack.upgrade(), position.x, position.y,
 			if (stack.count >= SHORT_NUM_CUTOFF) shortFormat(stack.count.toDouble())
 			else null
 		)
 		if (itemRect.contains(mouseX, mouseY)
 			&& context.containsPointInScissor(mouseX, mouseY)
 		) context.setTooltipForNextFrame(
-			MC.font, getTooltip(stack), Optional.empty(),
+			MC.font, getTooltip(stack.upgrade()), Optional.empty(),
 			mouseX, mouseY
 		)
 	}
@@ -73,8 +76,8 @@ class ItemSlotWidget(
 		var canUseTooltipEvent = true
 
 		fun getTooltip(itemStack: ItemStack): List<Component> {
-			val lore = mutableListOf(itemStack.displayNameAccordingToNbt)
-			lore.addAll(itemStack.loreAccordingToNbt)
+			val lore = mutableListOf(itemStack.accessor().displayNameAccordingToNbt)
+			lore.addAll(itemStack.accessor().loreAccordingToNbt)
 			if (canUseTooltipEvent) {
 				try {
 					ItemTooltipCallback.EVENT.invoker().getTooltip(
@@ -131,8 +134,9 @@ class ItemSlotWidget(
 	}
 
 	@OptIn(ExpensiveItemCacheApi::class)
+	@RequiresComponents
 	override fun getItemStack(): ItemStack {
-		return current().asImmutableItemStack()
+		return current().asImmutableItemStack().upgrade()
 	}
 
 	override fun getSkyBlockId(): String {

--- a/src/main/kotlin/features/mining/CommissionFeatures.kt
+++ b/src/main/kotlin/features/mining/CommissionFeatures.kt
@@ -6,6 +6,7 @@ import moe.nea.firmament.events.SlotRenderEvents
 import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.unformattedString
 
@@ -21,7 +22,7 @@ object CommissionFeatures {
 		if (!TConfig.highlightCompletedCommissions) return
 		if (MC.screenName != "Commissions") return
 		val stack = event.slot.item
-		if (stack.loreAccordingToNbt.any { it.unformattedString == "COMPLETED" }) {
+		if (stack.accessor().loreAccordingToNbt.any { it.unformattedString == "COMPLETED" }) {
 			event.highlight(Firmament.identifier("completed_commission_background"))
 		}
 	}

--- a/src/main/kotlin/features/mining/HotmPresets.kt
+++ b/src/main/kotlin/features/mining/HotmPresets.kt
@@ -29,6 +29,7 @@ import moe.nea.firmament.util.customgui.CustomGui
 import moe.nea.firmament.util.customgui.customGui
 import moe.nea.firmament.util.mc.CommonTextures
 import moe.nea.firmament.util.mc.SlotUtils.clickRightMouseButton
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.render.drawGuiTexture
 import moe.nea.firmament.util.unformattedString
@@ -145,7 +146,7 @@ object HotmPresets {
 			for (it in handler.slots) {
 				if (it.container is Inventory) continue
 				val stack = it.item
-				val name = stack.displayNameAccordingToNbt.unformattedString
+				val name = stack.accessor().displayNameAccordingToNbt.unformattedString
 				tierRegex.useMatch(name) {
 					coveredRows.add(group("tier").toInt())
 				}
@@ -188,7 +189,7 @@ object HotmPresets {
 	@Subscribe
 	fun onSlotRender(event: SlotRenderEvents.Before) {
 		if (hotmInventoryName == MC.screenName
-			&& event.slot.item.displayNameAccordingToNbt.unformattedString in highlightedPerks
+			&& event.slot.item.accessor().displayNameAccordingToNbt.unformattedString in highlightedPerks
 		) {
 			event.highlight((Firmament.identifier("hotm_perk_preset")))
 		}

--- a/src/main/kotlin/features/mining/PickaxeAbility.kt
+++ b/src/main/kotlin/features/mining/PickaxeAbility.kt
@@ -28,6 +28,7 @@ import moe.nea.firmament.util.TimeMark
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
 import moe.nea.firmament.util.extraAttributes
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.parseShortNumber
@@ -101,8 +102,8 @@ object PickaxeAbility {
 	@Subscribe
 	fun onSlotClick(it: SlotClickEvent) {
 		if (MC.screen?.title?.unformattedString == "Heart of the Mountain") {
-			val name = it.stack.displayNameAccordingToNbt.unformattedString
-			val cooldown = it.stack.loreAccordingToNbt.firstNotNullOfOrNull {
+			val name = it.stack.accessor().displayNameAccordingToNbt.unformattedString
+			val cooldown = it.stack.accessor().loreAccordingToNbt.firstNotNullOfOrNull {
 				cooldownPattern.useMatch(it.unformattedString) {
 					parseTimePattern(group("cooldown"))
 				}
@@ -114,14 +115,14 @@ object PickaxeAbility {
 	@Subscribe
 	fun onDurabilityBar(it: DurabilityBarEvent) {
 		if (!TConfig.drillFuelBar) return
-		val lore = it.item.loreAccordingToNbt
+		val lore = it.item.accessor().loreAccordingToNbt
 		if (lore.lastOrNull()?.unformattedString?.contains("DRILL") != true) return
 		val maxFuel = lore.firstNotNullOfOrNull {
 			fuelPattern.useMatch(it.unformattedString) {
 				parseShortNumber(group("maxFuel"))
 			}
 		} ?: return
-		val extra = it.item.extraAttributes
+		val extra = it.item.accessor().extraAttributes
 		val fuel = extra.getInt("drill_fuel").getOrNull() ?: return
 		var percentage = fuel / maxFuel.toFloat()
 		if (percentage > 1f) percentage = 1f
@@ -190,10 +191,10 @@ object PickaxeAbility {
 	)
 
 	fun getCooldownFromLore(itemStack: ItemStack): PickaxeAbilityData? {
-		val lore = itemStack.loreAccordingToNbt
+		val lore = itemStack.accessor().loreAccordingToNbt
 		if (!lore.any { it.unformattedString.contains("Breaking Power") })
 			return null
-		val ability = AbilityUtils.getAbilities(itemStack).firstOrNull() ?: return null
+		val ability = AbilityUtils.getAbilities(itemStack.accessor()).firstOrNull() ?: return null
 		return PickaxeAbilityData(ability.name, ability.cooldown ?: return null)
 	}
 
@@ -207,7 +208,7 @@ object PickaxeAbility {
 		if (TConfig.disableInDungeons && DungeonUtil.isInDungeonIsland) return
 		if (!event.isRenderingCursor) return
 		val stack = MC.player?.getItemInHand(InteractionHand.MAIN_HAND) ?: return
-		if (!TConfig.showOnTools.matches(ItemType.fromItemStack(stack) ?: ItemType.NIL))
+		if (!TConfig.showOnTools.matches(ItemType.fromItemStack(stack.accessor()) ?: ItemType.NIL))
 			return
 		var ability = getCooldownFromLore(stack)?.also { ability ->
 			defaultAbilityDurations[ability.name] = ability.cooldown

--- a/src/main/kotlin/gui/entity/ModifyEquipment.kt
+++ b/src/main/kotlin/gui/entity/ModifyEquipment.kt
@@ -11,6 +11,7 @@ import net.minecraft.world.item.Items
 import moe.nea.firmament.repo.ExpensiveItemCacheApi
 import moe.nea.firmament.repo.SBItemStack
 import moe.nea.firmament.util.SkyblockId
+import moe.nea.firmament.util.mc.RequiresComponents
 import moe.nea.firmament.util.mc.arbitraryUUID
 import moe.nea.firmament.util.mc.setEncodedSkullOwner
 
@@ -32,10 +33,10 @@ object ModifyEquipment : EntityModifier {
 		return entity
 	}
 
-	@OptIn(ExpensiveItemCacheApi::class)
+	@OptIn(ExpensiveItemCacheApi::class, RequiresComponents::class)
 	private fun createItem(item: String): ItemStack {
 		val split = item.split("#")
-		if (split.size != 2) return SBItemStack(SkyblockId(item)).asImmutableItemStack()
+		if (split.size != 2) return SBItemStack(SkyblockId(item)).asImmutableItemStack().upgrade()
 		val (type, data) = split
 		return when (type) {
 			"SKULL" -> ItemStack(Items.PLAYER_HEAD).also { it.setEncodedSkullOwner(arbitraryUUID, data) }

--- a/src/main/kotlin/impl/v1/FirmamentAPIImpl.kt
+++ b/src/main/kotlin/impl/v1/FirmamentAPIImpl.kt
@@ -13,6 +13,7 @@ import moe.nea.firmament.features.items.recipes.ItemList
 import moe.nea.firmament.repo.ExpensiveItemCacheApi
 import moe.nea.firmament.util.MC
 import moe.nea.firmament.util.intoOptional
+import moe.nea.firmament.util.mc.RequiresComponents
 
 object FirmamentAPIImpl : FirmamentAPI() {
 	@JvmField
@@ -40,8 +41,9 @@ object FirmamentAPIImpl : FirmamentAPI() {
 					return FirmamentItemWidget.Placement.ITEM_LIST
 				}
 
+				@RequiresComponents
 				override fun getItemStack(): ItemStack {
-					return itemListStack.second.asImmutableItemStack()
+					return itemListStack.second.asImmutableItemStack().upgrade()
 				}
 
 				override fun getSkyBlockId(): String {

--- a/src/main/kotlin/repo/ItemCache.kt
+++ b/src/main/kotlin/repo/ItemCache.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.withContext
 import kotlin.io.path.readText
 import kotlin.jvm.optionals.getOrNull
 import net.minecraft.SharedConstants
+import net.minecraft.core.component.DataComponentPatch
 import net.minecraft.core.component.DataComponents
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.nbt.NbtOps
@@ -32,6 +33,7 @@ import net.minecraft.resources.Identifier
 import net.minecraft.util.datafix.DataFixers
 import net.minecraft.util.datafix.fixes.References
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.ItemStackTemplate
 import net.minecraft.world.item.Items
 import net.minecraft.world.item.component.CustomData
 import moe.nea.firmament.Firmament
@@ -43,7 +45,10 @@ import moe.nea.firmament.util.MinecraftDispatcher
 import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.TestUtil
 import moe.nea.firmament.util.directLiteralStringContent
+import moe.nea.firmament.util.mc.DataComponentAccessor
+import moe.nea.firmament.util.mc.DataComponentMutator
 import moe.nea.firmament.util.mc.FirmamentDataComponentTypes
+import moe.nea.firmament.util.mc.LazyItemStack
 import moe.nea.firmament.util.mc.appendLore
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loadItemFromNbt
@@ -55,7 +60,7 @@ import moe.nea.firmament.util.skyblockId
 import moe.nea.firmament.util.transformEachRecursively
 
 object ItemCache : IReloadable {
-	private val cache: MutableMap<String, ItemStack> = ConcurrentHashMap()
+	private val cache: MutableMap<String, LazyItemStack> = ConcurrentHashMap()
 	private val df = DataFixers.getDataFixer()
 	val logger = LogManager.getLogger("${Firmament.logger.name}.ItemCache")
 	var isFlawless = true
@@ -87,16 +92,16 @@ object ItemCache : IReloadable {
 			null
 		}
 
-	val ItemStack.isBroken
+	val DataComponentAccessor.isBroken
 		get() = get(FirmamentDataComponentTypes.IS_BROKEN) ?: false
 
-	fun ItemStack.withFallback(fallback: ItemStack?): ItemStack {
+	fun LazyItemStack.withFallback(fallback: LazyItemStack?): LazyItemStack {
 		if (isBroken && fallback != null) return fallback
 		return this
 	}
 
-	fun brokenItemStack(neuItem: NEUItem?, idHint: SkyblockId? = null): ItemStack {
-		return ItemStack(Items.PAINTING).apply {
+	fun brokenItemStack(neuItem: NEUItem?, idHint: SkyblockId? = null): LazyItemStack {
+		return LazyItemStack.build(Items.PAINTING) {
 			setCustomName(Component.literal(neuItem?.displayName ?: idHint?.neuItem ?: "null"))
 			appendLore(
 				listOf(
@@ -159,8 +164,7 @@ object ItemCache : IReloadable {
 	}
 
 	@ExpensiveItemCacheApi
-	private fun NEUItem.asItemStackNow(): ItemStack {
-
+	private fun NEUItem.asItemStackNow(): LazyItemStack {
 		try {
 			var modernItemTag = tryFindFromModernFormat(this.skyblockId)
 			val oldItemTag = get10809CompoundTag()
@@ -170,8 +174,7 @@ object ItemCache : IReloadable {
 				modernItemTag = oldItemTag.transformFrom10809ToModern()
 					?: return brokenItemStack(this)
 			}
-			val itemInstance =
-				loadItemFromNbt( modernItemTag) ?: return brokenItemStack(this)
+			val itemInstance = loadItemFromNbt(modernItemTag)?.intoMutable() ?: return brokenItemStack(this)
 			if (usedOldNbt) {
 				val tag = oldItemTag.getCompound("tag")
 				val extraAttributes = tag.flatMap { it.getCompound("ExtraAttributes") }
@@ -184,7 +187,7 @@ object ItemCache : IReloadable {
 			}
 			itemInstance.loreAccordingToNbt = lore.map { un189Lore(it) }
 			itemInstance.displayNameAccordingToNbt = un189Lore(displayName)
-			return itemInstance
+			return itemInstance.finish()
 		} catch (e: Exception) {
 			e.printStackTrace()
 			return brokenItemStack(this)
@@ -196,7 +199,7 @@ object ItemCache : IReloadable {
 	}
 
 	@ExpensiveItemCacheApi
-	fun NEUItem?.asItemStack(idHint: SkyblockId? = null, loreReplacements: Map<String, String>? = null): ItemStack {
+	fun NEUItem?.asItemStack(idHint: SkyblockId? = null, loreReplacements: Map<String, String>? = null): LazyItemStack {
 		if (this == null) return brokenItemStack(null, idHint)
 		var s = cache[this.skyblockItemId]
 		if (s == null) {
@@ -204,14 +207,17 @@ object ItemCache : IReloadable {
 			cache[this.skyblockItemId] = s
 		}
 		if (!loreReplacements.isNullOrEmpty()) {
-			s = s.copy()!!
-			s.applyLoreReplacements(loreReplacements)
-			s.setCustomName(s.hoverName.applyLoreReplacements(loreReplacements))
+			s = s.withMutations {
+				applyLoreReplacements(loreReplacements)
+				get(DataComponents.CUSTOM_NAME)?.let {
+					setCustomName(it)
+				}
+			}
 		}
 		return s
 	}
 
-	fun ItemStack.applyLoreReplacements(loreReplacements: Map<String, String>) {
+	fun DataComponentMutator.applyLoreReplacements(loreReplacements: Map<String, String>) {
 		modifyLore { lore ->
 			lore.map {
 				it.applyLoreReplacements(loreReplacements)
@@ -274,7 +280,7 @@ object ItemCache : IReloadable {
 		itemRecacheScope = newScope
 	}
 
-	fun coinItem(coinAmount: Int): ItemStack {
+	fun coinItem(coinAmount: Int): LazyItemStack {
 		var uuid = UUID.fromString("2070f6cb-f5db-367a-acd0-64d39a7e5d1b")
 		var texture =
 			"http://textures.minecraft.net/texture/538071721cc5b4cd406ce431a13f86083a8973e1064d2f8897869930ee6e5237"
@@ -288,10 +294,10 @@ object ItemCache : IReloadable {
 			texture =
 				"http://textures.minecraft.net/texture/7b951fed6a7b2cbc2036916dec7a46c4a56481564d14f945b6ebc03382766d3b"
 		}
-		val itemStack = ItemStack(Items.PLAYER_HEAD)
-		itemStack.setCustomName(Component.literal("§r§6" + NumberFormat.getInstance().format(coinAmount) + " Coins"))
-		itemStack.setSkullOwner(uuid, texture)
-		return itemStack
+		return LazyItemStack.build(Items.PLAYER_HEAD) {
+			setCustomName(Component.literal("§r§6" + NumberFormat.getInstance().format(coinAmount) + " Coins"))
+			setSkullOwner(uuid, texture)
+		}
 	}
 
 	init {

--- a/src/main/kotlin/repo/MiningRepoData.kt
+++ b/src/main/kotlin/repo/MiningRepoData.kt
@@ -19,8 +19,10 @@ import moe.nea.firmament.util.SBData
 import moe.nea.firmament.util.SkyBlockIsland
 import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.mc.FirmamentDataComponentTypes
+import moe.nea.firmament.util.mc.RequiresComponents
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loadItemFromNbt
+import moe.nea.firmament.util.mc.mutator
 import moe.nea.firmament.util.skyblockId
 
 class MiningRepoData : IReloadable {
@@ -79,15 +81,15 @@ class MiningRepoData : IReloadable {
 	) {
 		@Transient
 		val dropItem = baseDrop?.let(::SBItemStack)
-		@OptIn(ExpensiveItemCacheApi::class)
+		@OptIn(ExpensiveItemCacheApi::class, RequiresComponents::class)
 		private val labeledStack by lazy {
-			dropItem?.asCopiedItemStack()?.also(::markItemStack)
+			dropItem?.asImmutableItemStack()?.copiedUpgrade()?.also(::markItemStack)
 		}
 
 		private fun markItemStack(itemStack: ItemStack) {
-			itemStack.set(FirmamentDataComponentTypes.CUSTOM_MINING_BLOCK_DATA, this)
+			itemStack.mutator().set(FirmamentDataComponentTypes.CUSTOM_MINING_BLOCK_DATA, this)
 			if (name != null)
-				itemStack.displayNameAccordingToNbt = Component.literal(name)
+				itemStack.mutator().displayNameAccordingToNbt = Component.literal(name)
 		}
 
 		fun getDisplayItem(block: Block): ItemStack {

--- a/src/main/kotlin/repo/SBItemStack.kt
+++ b/src/main/kotlin/repo/SBItemStack.kt
@@ -14,6 +14,7 @@ import net.minecraft.network.chat.Component
 import net.minecraft.network.chat.TextColor
 import net.minecraft.ChatFormatting
 import moe.nea.firmament.repo.ItemCache.asItemStack
+import moe.nea.firmament.repo.ItemCache.isBroken
 import moe.nea.firmament.repo.ItemCache.withFallback
 import moe.nea.firmament.util.FirmFormatters
 import moe.nea.firmament.util.LegacyFormattingCode
@@ -26,6 +27,10 @@ import moe.nea.firmament.util.extraAttributes
 import moe.nea.firmament.util.getReforgeId
 import moe.nea.firmament.util.getUpgradeStars
 import moe.nea.firmament.util.grey
+import moe.nea.firmament.util.mc.DataComponentAccessor
+import moe.nea.firmament.util.mc.DataComponentMutator
+import moe.nea.firmament.util.mc.LazyItemStack
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.appendLore
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loreAccordingToNbt
@@ -50,7 +55,7 @@ data class SBItemStack constructor(
 	private var petData: PetData?,
 	val extraLore: List<Component> = emptyList(),
 	val stars: Int = 0,
-	val fallback: ItemStack? = null,
+	val fallback: LazyItemStack? = null,
 	val reforge: ReforgeId? = null,
 ) {
 
@@ -83,7 +88,9 @@ data class SBItemStack constructor(
 		val EMPTY = SBItemStack(SkyblockId.NULL, 0)
 
 		private val BREAKING_POWER_REGEX = "Breaking Power (?<power>[0-9]+)".toPattern()
-		operator fun invoke(itemStack: ItemStack): SBItemStack {
+		operator fun invoke(itemStack: ItemStack): SBItemStack=
+			invoke(itemStack.accessor())
+		operator fun invoke(itemStack: DataComponentAccessor): SBItemStack {
 			val skyblockId = itemStack.skyBlockId ?: SkyblockId.NULL
 			return SBItemStack(
 				skyblockId,
@@ -103,11 +110,11 @@ data class SBItemStack constructor(
 			return SBItemStack(neuIngredient.skyblockId, neuIngredient.amount.toInt())
 		}
 
-		fun passthrough(itemStack: ItemStack): SBItemStack {
+		fun passthrough(itemStack: LazyItemStack): SBItemStack {
 			return SBItemStack(SkyblockId.NULL, null, itemStack.count, null, fallback = itemStack)
 		}
 
-		fun parseStatBlock(itemStack: ItemStack): List<StatLine> {
+		fun parseStatBlock(itemStack: DataComponentAccessor): List<StatLine> {
 			return itemStack.loreAccordingToNbt
 				.map { parseStatLine(it) }
 				.takeWhile { it != null }
@@ -115,7 +122,7 @@ data class SBItemStack constructor(
 		}
 
 		fun appendEnhancedStats(
-			itemStack: ItemStack,
+			itemStack: DataComponentMutator,
 			reforgeStats: Map<String, Double>,
 			buffKind: BuffKind,
 		) {
@@ -322,7 +329,7 @@ data class SBItemStack constructor(
 
 
 	private fun appendReforgeInfo(
-		itemStack: ItemStack,
+		itemStack: DataComponentMutator,
 	) {
 		val rarity = Rarity.fromItem(itemStack) ?: return
 		val reforgeId = this.reforge ?: return
@@ -361,7 +368,7 @@ data class SBItemStack constructor(
 	@ExpensiveItemCacheApi
 	val rarity: Rarity? get() = Rarity.fromItem(asImmutableItemStack())
 
-	private var itemStack_: ItemStack? = null
+	private var itemStack_: LazyItemStack? = null
 
 	val breakingPower: Int
 		get() =
@@ -370,23 +377,24 @@ data class SBItemStack constructor(
 			} ?: 0
 
 	@ExpensiveItemCacheApi
-	private val itemStack: ItemStack
+	private val itemStack: LazyItemStack
 		get() {
 			val itemStack = itemStack_ ?: run {
 				if (skyblockId == SkyblockId.COINS)
-					return@run ItemCache.coinItem(stackSize).also { it.appendLore(extraLore) }
+					return@run ItemCache.coinItem(stackSize).withMutations { appendLore(extraLore) }
 				if (stackSize == 0)
-					return@run ItemStack.EMPTY
+					return@run LazyItemStack.empty()
 				val replacementData = mutableMapOf<String, String>()
 				injectReplacementDataForPets(replacementData)
 				val baseItem = neuItem.asItemStack(idHint = skyblockId, replacementData)
 					.withFallback(fallback)
-					.copyWithCount(stackSize)
+					.withCount(stackSize)
+					.intoMutable()
 				val baseStats = parseStatBlock(baseItem)
 				appendReforgeInfo(baseItem)
 				baseItem.appendLore(extraLore)
 				enhanceStatsByStars(baseItem, stars, baseStats)
-				return@run baseItem
+				return@run baseItem.finish()
 			}
 			if (itemStack_ == null && !itemStack.isBroken)
 				itemStack_ = itemStack
@@ -423,7 +431,7 @@ data class SBItemStack constructor(
 		return starString
 	}
 
-	private fun enhanceStatsByStars(itemStack: ItemStack, stars: Int, baseStats: List<StatLine>) {
+	private fun enhanceStatsByStars(itemStack: DataComponentMutator, stars: Int, baseStats: List<StatLine>) {
 		if (stars == 0) return
 		// TODO: increase stats and add the star level into the nbt data so star displays work
 		itemStack.modifyExtraAttributes {
@@ -451,18 +459,13 @@ data class SBItemStack constructor(
 	}
 
 	@OptIn(ExpensiveItemCacheApi::class)
-	fun asLazyImmutableItemStack(): ItemStack? {
-		if (isWarm()) return asImmutableItemStack()
+	fun asLazyImmutableItemStack(): LazyItemStack? {
+		if (isWarm()) return itemStack
 		return null
 	}
 
 	@ExpensiveItemCacheApi
-	fun asImmutableItemStack(): ItemStack { // TODO: add a "or fallback to painting" option to asLazyImmutableItemStack to be used in more places.
+	fun asImmutableItemStack(): LazyItemStack { // TODO: add a "or fallback to painting" option to asLazyImmutableItemStack to be used in more places.
 		return itemStack
-	}
-
-	@ExpensiveItemCacheApi
-	fun asCopiedItemStack(): ItemStack {
-		return itemStack.copy()
 	}
 }

--- a/src/main/kotlin/util/SkyblockId.kt
+++ b/src/main/kotlin/util/SkyblockId.kt
@@ -20,6 +20,7 @@ import kotlin.jvm.optionals.getOrNull
 import net.minecraft.core.component.DataComponents
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.network.RegistryFriendlyByteBuf
+import net.minecraft.network.chat.CommonComponents
 import net.minecraft.network.codec.ByteBufCodecs
 import net.minecraft.network.codec.StreamCodec
 import net.minecraft.resources.Identifier
@@ -35,6 +36,10 @@ import moe.nea.firmament.repo.set
 import moe.nea.firmament.util.collections.WeakCache
 import moe.nea.firmament.util.json.DashlessUUIDSerializer
 import moe.nea.firmament.util.mc.CompoundMutationChecker
+import moe.nea.firmament.util.mc.DataComponentAccessor
+import moe.nea.firmament.util.mc.DataComponentMutator
+import moe.nea.firmament.util.mc.RequiresComponents
+import moe.nea.firmament.util.mc.defaultItemStack
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.mc.unsafeNbt
@@ -129,22 +134,25 @@ data class HypixelPetInfo(
 
 private val jsonparser = Json { ignoreUnknownKeys = true }
 
-var ItemStack.extraAttributes: CompoundTag
-	set(value) {
-		set(DataComponents.CUSTOM_DATA, CustomData.of(value))
-	}
+val DataComponentAccessor.extraAttributes: CompoundTag
 	get() {
 		val customData = get(DataComponents.CUSTOM_DATA)?.unsafeNbt ?: CompoundTag()
 		return CompoundMutationChecker.disallowMutations(customData)
 	}
 
-fun ItemStack.modifyExtraAttributes(block: (CompoundTag) -> Unit) {
+var DataComponentMutator.extraAttributes: CompoundTag
+	get() = (this as DataComponentAccessor).extraAttributes
+	set(value) {
+		set(DataComponents.CUSTOM_DATA, CustomData.of(value))
+	}
+
+fun DataComponentMutator.modifyExtraAttributes(block: (CompoundTag) -> Unit) {
 	val baseNbt = get(DataComponents.CUSTOM_DATA)?.copyTag() ?: CompoundTag()
 	block(baseNbt)
 	set(DataComponents.CUSTOM_DATA, CustomData.of(baseNbt))
 }
 
-val ItemStack.skyBlockUUIDString: String?
+val DataComponentAccessor.skyBlockUUIDString: String?
 	get() = extraAttributes.getString("uuid").getOrNull()?.takeIf { it.isNotBlank() }
 
 private val timestampFormat = //"10/11/21 3:39 PM"
@@ -162,7 +170,7 @@ private val timestampFormat = //"10/11/21 3:39 PM"
 		appendLiteral(" ")
 		appendText(ChronoField.AMPM_OF_DAY)
 	}.toFormatter()
-val ItemStack.timestamp
+val DataComponentAccessor.timestamp
 	get() =
 		extraAttributes.getLong("timestamp").getOrNull()?.let { Instant.ofEpochMilli(it) }
 			?: extraAttributes.getString("timestamp").getOrNull()?.let {
@@ -172,10 +180,10 @@ val ItemStack.timestamp
 				}.orNull()
 			}
 
-val ItemStack.skyblockUUID: UUID?
+val DataComponentAccessor.skyblockUUID: UUID?
 	get() = skyBlockUUIDString?.let { UUID.fromString(it) }
 
-private val petDataCache = WeakCache.memoize<ItemStack, Optional<HypixelPetInfo>>("PetInfo") {
+private val petDataCache = WeakCache.memoize<DataComponentAccessor, Optional<HypixelPetInfo>>("PetInfo") { // TODO: this will not memoize correctly since i wrap into DataComponentAccessor!
 	val jsonString = it.extraAttributes.getString("petInfo")
 		.getOrNull()
 	if (jsonString.isNullOrBlank()) return@memoize Optional.empty()
@@ -185,7 +193,7 @@ private val petDataCache = WeakCache.memoize<ItemStack, Optional<HypixelPetInfo>
 		.or { null }.intoOptional()
 }
 
-fun ItemStack.getUpgradeStars(): Int {
+fun DataComponentAccessor.getUpgradeStars(): Int {
 	return extraAttributes.getInt("upgrade_level").getOrNull()?.takeIf { it > 0 }
 		?: extraAttributes.getInt("dungeon_item_level").getOrNull()?.takeIf { it > 0 }
 		?: 0
@@ -195,15 +203,17 @@ fun ItemStack.getUpgradeStars(): Int {
 @JvmInline
 value class ReforgeId(val id: String)
 
-fun ItemStack.getReforgeId(): ReforgeId? {
+fun DataComponentAccessor.getReforgeId(): ReforgeId? {
 	return extraAttributes.getString("modifier").getOrNull()?.takeIf { it.isNotBlank() }?.let(::ReforgeId)
 }
 
-val ItemStack.petData: HypixelPetInfo?
+val DataComponentAccessor.petData: HypixelPetInfo?
 	get() = petDataCache(this).getOrNull()
 
-fun ItemStack.setSkyBlockFirmamentUiId(uiId: String) = setSkyBlockId(SkyblockId("FIRMAMENT_UI_$uiId"))
-fun ItemStack.setSkyBlockId(skyblockId: SkyblockId): ItemStack {
+fun <T : DataComponentMutator> T.setSkyBlockFirmamentUiId(uiId: String) =
+	setSkyBlockId(SkyblockId("FIRMAMENT_UI_$uiId"))
+
+fun <T : DataComponentMutator> T.setSkyBlockId(skyblockId: SkyblockId): T {
 	modifyExtraAttributes { tag ->
 		tag["id"] = skyblockId.neuItem
 	}
@@ -214,7 +224,7 @@ private val STORED_REGEX = "Stored: ($SHORT_NUMBER_FORMAT)/.+".toPattern()
 private val COMPOST_REGEX = "Compost Available: ($SHORT_NUMBER_FORMAT)".toPattern()
 private val GEMSTONE_SACK_REGEX = " Amount: ($SHORT_NUMBER_FORMAT)".toPattern()
 private val AMOUNT_REGEX = ".*(?:Offer amount|Amount|Order amount): ($SHORT_NUMBER_FORMAT)x".toPattern()
-fun ItemStack.getLogicalStackSize(): Long {
+fun DataComponentAccessor.getLogicalStackSize(): Long {
 	return loreAccordingToNbt.firstNotNullOfOrNull {
 		val string = it.unformattedString
 		GEMSTONE_SACK_REGEX.useMatch(string) {
@@ -229,9 +239,9 @@ fun ItemStack.getLogicalStackSize(): Long {
 	} ?: count.toLong()
 }
 
-val ItemStack.rawSkyBlockId: String? get() = extraAttributes.getString("id").getOrNull()
+val DataComponentAccessor.rawSkyBlockId: String? get() = extraAttributes.getString("id").getOrNull()
 
-fun ItemStack.guessContextualSkyBlockId(): SkyblockId? {
+fun DataComponentAccessor.guessContextualSkyBlockId(): SkyblockId? {
 	val screen = MC.screen
 	val screenType = ScreenIdentification.getType(screen)
 	if (screenType == ScreenType.BAZAAR_ANY || screenType == ScreenType.DYE_COMPENDIUM) {
@@ -256,7 +266,7 @@ fun ItemStack.guessContextualSkyBlockId(): SkyblockId? {
 			.dropWhile { !it.unformattedString.isBlank() }
 			.drop(1)
 			.firstOrNull()
-			?.unformattedString ?: displayName.unformattedString
+			?.unformattedString ?: displayNameAccordingToNbt.unformattedString
 		return RepoManager.enchantedBookCache.byName[name]
 			?: ItemNameLookup.guessItemByName(name, false)
 
@@ -264,7 +274,11 @@ fun ItemStack.guessContextualSkyBlockId(): SkyblockId? {
 	return null
 }
 
-val ItemStack.skyBlockId: SkyblockId?
+@RequiresComponents
+val DataComponentAccessor.renderingName
+	get() = displayNameAccordingToNbt.takeUnless { it === CommonComponents.EMPTY } ?: (maybeItemStack() ?: defaultItemStack()).hoverName
+
+val DataComponentAccessor.skyBlockId: SkyblockId?
 	get() {
 		return when (val id = rawSkyBlockId) {
 			"", null -> {

--- a/src/main/kotlin/util/mc/ItemUtil.kt
+++ b/src/main/kotlin/util/mc/ItemUtil.kt
@@ -7,9 +7,10 @@ import net.minecraft.nbt.NbtOps
 import net.minecraft.resources.RegistryOps
 import net.minecraft.core.HolderLookup
 import net.minecraft.network.chat.Component
+import net.minecraft.world.item.ItemStackTemplate
 import moe.nea.firmament.util.MC
 
-fun ItemStack.appendLore(args: List<Component>) {
+fun DataComponentMutator.appendLore(args: List<Component>) {
 	if (args.isEmpty()) return
 	modifyLore {
 		val loreList = loreAccordingToNbt.toMutableList()
@@ -20,11 +21,12 @@ fun ItemStack.appendLore(args: List<Component>) {
 	}
 }
 
-fun ItemStack.modifyLore(update: (List<Component>) -> List<Component>) {
+fun DataComponentMutator.modifyLore(update: (List<Component>) -> List<Component>) {
 	val loreList = loreAccordingToNbt
 	loreAccordingToNbt = update(loreList)
 }
 
-fun loadItemFromNbt(nbt: CompoundTag, registries: HolderLookup.Provider = MC.defaultRegistries): ItemStack? {
-	return ItemStack.CODEC.decode(RegistryOps.create(NbtOps.INSTANCE, registries), nbt).result().getOrNull()?.first
+fun loadItemFromNbt(nbt: CompoundTag, registries: HolderLookup.Provider = MC.defaultRegistries): LazyItemStack? {
+	return ItemStackTemplate.CODEC.decode(RegistryOps.create(NbtOps.INSTANCE, registries), nbt)
+		.result().getOrNull()?.first?.let(LazyItemStack::fromTemplate)
 }

--- a/src/main/kotlin/util/mc/LazyItemStack.kt
+++ b/src/main/kotlin/util/mc/LazyItemStack.kt
@@ -1,52 +1,183 @@
 package moe.nea.firmament.util.mc
 
-import com.mojang.datafixers.util.Pair
 import com.mojang.serialization.Codec
-import com.mojang.serialization.DataResult
-import com.mojang.serialization.DynamicOps
+import java.util.*
+import kotlin.jvm.optionals.getOrNull
+import net.minecraft.core.Holder
+import net.minecraft.core.TypedInstance
+import net.minecraft.core.component.*
+import net.minecraft.resources.ResourceKey
+import net.minecraft.util.ExtraCodecs
+import net.minecraft.world.item.Item
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.ItemStackTemplate
+import net.minecraft.world.item.Items
+import net.minecraft.world.level.ItemLike
 import moe.nea.firmament.events.ComponentsLoadedEvent
 
 @RequiresOptIn
 annotation class RequiresComponents
 
-class LazyItemStack {
+interface DataComponentAccessor {
+	fun <T : Any> getWithDefault(prototype: DataComponentGetter, component: DataComponentType<T>): T?
+	val item: Holder<Item>
+	val itemId: ResourceKey<Item>
+		get() = item.unwrapKey().orElseThrow()
+	val count: Int
+
+	fun maybeItemStack(): ItemStack? = null
+
+	fun <T : Any> get(component: DataComponentType<T>): T? {
+		return getWithDefault(NullData, component)
+	}
+
+	@RequiresComponents
+	fun <T : Any> getWithDefault(component: DataComponentType<T>): T? {
+		return getWithDefault(item.components(), component)
+	}
+
+}
+
+@RequiresComponents
+fun DataComponentAccessor.defaultItemStack() = item.value().defaultInstance
+
+fun DataComponentAccessor.isEmpty() = count == 0 || isItem(Items.AIR)
+fun DataComponentAccessor.isItem(item: ItemLike): Boolean = this.item.`is`(item.asItem().builtInRegistryHolder())
+fun ItemStack.lazy() = LazyItemStack.fromItemStack(this)
+open class ItemStackAccessor(val itemStack: ItemStack) : DataComponentAccessor {
+
+	override fun <T : Any> getWithDefault(prototype: DataComponentGetter, component: DataComponentType<T>): T? {
+		return itemStack.componentsPatch.get(prototype, component)
+	}
+
+	override fun maybeItemStack(): ItemStack = itemStack
+
+	override val item: Holder<Item>
+		get() = itemStack.typeHolder()
+	override val count: Int
+		get() = itemStack.count
+}
+
+fun ItemStack.accessor(): DataComponentAccessor = ItemStackAccessor(this)
+fun ItemStack.mutator(): DataComponentMutator = object : ItemStackAccessor(this), DataComponentMutator {
+	override fun <T : Any> set(component: DataComponentType<T>, data: T) {
+		itemStack.set(component, data)
+	}
+
+	override fun remove(type: DataComponentType<*>) {
+		itemStack.remove(type)
+	}
+}
+
+interface DataComponentSetter {
+	fun <T : Any> set(component: DataComponentType<T>, data: T)
+	fun remove(type: DataComponentType<*>)
+}
+
+interface DataComponentMutator : DataComponentAccessor, DataComponentSetter
+
+class DataComponentPatchAccessor(
+	override val item: Holder<Item>,
+	val patch: DataComponentPatch
+) : DataComponentAccessor {
+	override fun <T : Any> getWithDefault(prototype: DataComponentGetter, component: DataComponentType<T>): T? {
+		return patch.get(prototype, component)
+	}
+
+	override val count: Int
+		get() = 1
+}
+
+class MutableItemTemplate(
+	override val item: Holder<Item>,
+	override var count: Int,
+	var components: DataComponentPatch.Builder,
+) : DataComponentMutator {
+	override fun <T : Any> set(component: DataComponentType<T>, data: T) {
+		components.set(component, data)
+	}
+
+	override fun remove(type: DataComponentType<*>) {
+		components.remove(type)
+	}
+
+	@RequiresComponents
+	fun collapseDefaults() = collapseDefaults(item.components())
+
+	fun collapseDefaults(prototype: DataComponentMap) {
+		components = PatchedDataComponentMap.fromPatch(prototype, components.build())
+			.asPatch()
+			.toBuilder()
+	}
+
+	override fun <T : Any> getWithDefault(prototype: DataComponentGetter, component: DataComponentType<T>): T? {
+		return components.build().get(prototype, component)
+	}
+
+	fun finishNonEmpty() = ItemStackTemplate(item, count, components.build())
+
+	fun finish() = LazyItemStack.fromMutableTemplate(this)
+}
+
+fun DataComponentPatch.toBuilder(): DataComponentPatch.Builder {
+	val builder = DataComponentPatch.builder()
+	for ((k, v) in entrySet()) {
+		if (v.isEmpty)
+			builder.remove(k)
+		else
+			@Suppress("UNCHECKED_CAST")
+			builder.set(k as DataComponentType<Any>, v.get())
+	}
+	return builder
+}
+
+object NullData : DataComponentGetter {
+	override fun <T : Any> get(type: DataComponentType<out T>): T? {
+		return null
+	}
+}
+
+open class LazyItemStack private constructor() : DataComponentAccessor, TypedInstance<Item> {
 	companion object {
 		fun fromItemStack(itemStack: ItemStack) = LazyItemStack().also { it._itemStack = itemStack }
 		fun fromTemplate(template: ItemStackTemplate?) = LazyItemStack().also { it._template = template }
-		fun empty() = LazyItemStack()
-		val CODEC =
-			object : Codec<LazyItemStack> {
-				override fun <T> encode(
-					input: LazyItemStack,
-					ops: DynamicOps<T>,
-					prefix: T
-				): DataResult<T> {
-					return input.template()?.let {
-						ItemStackTemplate.CODEC.encode(it, ops, prefix)
-					} ?: DataResult.success(ops.emptyMap())
-				}
+		fun fromMutableTemplate(template: MutableItemTemplate) =
+			if (template.isEmpty()) empty()
+			else fromTemplate(template.finishNonEmpty())
 
-				override fun <T> decode(
-					ops: DynamicOps<T>,
-					input: T
-				): DataResult<Pair<LazyItemStack, T>> {
-					return ops.getMap(input)
-						.flatMap { map ->
-							if (map.entries().findAny().isEmpty)
-								DataResult.success(Pair(empty(), ops.empty()))
-							else
-								ItemStackTemplate.CODEC.decode(ops, input)
-									.map { it.mapFirst(::fromTemplate) }
-						}
-				}
-			}
+		fun build(item: ItemLike, builder: DataComponentMutator.() -> Unit = {}) =
+			build(item.asItem().builtInRegistryHolder(), builder)
+
+		fun build(item: Holder<Item>, builder: DataComponentMutator.() -> Unit = {}) =
+			fromMutableTemplate(
+				MutableItemTemplate(item, 1, DataComponentPatch.builder())
+					.also(builder)
+			)
+
+		fun empty() = LazyItemStack()
+
+		val CODEC: Codec<LazyItemStack> = ExtraCodecs.optionalEmptyMap(ItemStackTemplate.CODEC)
+			.xmap(
+				{ fromTemplate(it.getOrNull()) },
+				{ Optional.ofNullable(it.template()) })
+	}
+
+	fun intoMutable(): MutableItemTemplate {
+		_template?.let { template ->
+			return MutableItemTemplate(template.typeHolder(), template.count, template.components.toBuilder())
+		}
+		_itemStack?.let { stack ->
+			return MutableItemTemplate(stack.typeHolder(), stack.count, stack.componentsPatch.toBuilder())
+		}
+		return MutableItemTemplate(typeHolder(), 1, DataComponentPatch.builder())
 	}
 
 	private var _itemStack: ItemStack? = null
 	private var _template: ItemStackTemplate? = null
-	private var generation = -1
+	private var generation = ComponentsLoadedEvent.generation
+
+	fun withMutations(builder: MutableItemTemplate.() -> Unit) =
+		intoMutable().also(builder).finish()
 
 	fun template(): ItemStackTemplate? {
 		if (_template == null)
@@ -60,6 +191,11 @@ class LazyItemStack {
 	fun recreate(): ItemStack {
 		return (_template?.create() ?: ItemStack.EMPTY)
 			.also { this._itemStack = it }
+	}
+
+	@RequiresComponents
+	fun copiedUpgrade(): ItemStack {
+		return upgrade().copy()
 	}
 
 	@RequiresComponents
@@ -77,6 +213,29 @@ class LazyItemStack {
 	fun decay() {
 		template()
 		_itemStack = null
+	}
+
+	override val item: Holder<Item>
+		get() = _itemStack?.typeHolder() ?: _template?.typeHolder() ?: Items.AIR.builtInRegistryHolder()
+	override val count: Int
+		get() = _itemStack?.count ?: _template?.count ?: 0
+
+	override fun <T : Any> getWithDefault(prototype: DataComponentGetter, component: DataComponentType<T>): T? {
+		tryDecay()
+		val patch = _itemStack?.componentsPatch ?: _template?.components ?: return null
+		return DataComponentPatchAccessor(item, patch).getWithDefault(prototype, component)
+	}
+
+	override fun typeHolder(): Holder<Item> = item
+	fun withCount(count: Int): LazyItemStack {
+		return LazyItemStack().also {
+			it._itemStack = _itemStack?.copyWithCount(count)
+			it._template = _template?.withCount(count)
+		}
+	}
+
+	override fun maybeItemStack(): ItemStack? {
+		return _itemStack
 	}
 }
 

--- a/src/main/kotlin/util/mc/NbtItemData.kt
+++ b/src/main/kotlin/util/mc/NbtItemData.kt
@@ -1,22 +1,29 @@
 package moe.nea.firmament.util.mc
 
 import net.minecraft.core.component.DataComponents
+import net.minecraft.network.chat.CommonComponents
 import net.minecraft.world.item.component.ItemLore
 import net.minecraft.world.item.ItemStack
 import net.minecraft.network.chat.Component
 
-var ItemStack.loreAccordingToNbt: List<Component>
+val DataComponentAccessor.loreAccordingToNbt: List<Component>
 	get() = get(DataComponents.LORE)?.lines ?: listOf()
-    set(value) {
-        set(DataComponents.LORE, ItemLore(value))
-    }
 
-var ItemStack.displayNameAccordingToNbt: Component
-    get() = get(DataComponents.CUSTOM_NAME) ?: get(DataComponents.ITEM_NAME) ?: item.getName(this)
-    set(value) {
-        set(DataComponents.CUSTOM_NAME, value)
-    }
+var DataComponentMutator.loreAccordingToNbt: List<Component>
+	get() = (this as DataComponentAccessor).loreAccordingToNbt
+	set(value) {
+		set(DataComponents.LORE, ItemLore(value))
+	}
 
-fun ItemStack.setCustomName(text: Component) {
-    set(DataComponents.CUSTOM_NAME, text)
+val DataComponentAccessor.displayNameAccordingToNbt: Component
+	get() = get(DataComponents.CUSTOM_NAME) ?: get(DataComponents.ITEM_NAME) ?: CommonComponents.EMPTY
+
+var DataComponentMutator.displayNameAccordingToNbt: Component
+	get() = (this as DataComponentAccessor).displayNameAccordingToNbt
+	set(value) {
+		set(DataComponents.CUSTOM_NAME, value)
+	}
+
+fun DataComponentMutator.setCustomName(text: Component) {
+	set(DataComponents.CUSTOM_NAME, text)
 }

--- a/src/main/kotlin/util/mc/SkullItemData.kt
+++ b/src/main/kotlin/util/mc/SkullItemData.kt
@@ -61,10 +61,9 @@ fun ItemStack.setEncodedSkullOwner(uuid: UUID, encodedData: String) {
 }
 
 val arbitraryUUID = UUID.fromString("d3cb85e2-3075-48a1-b213-a9bfb62360c1")
-fun createSkullItem(uuid: UUID, url: String) = ItemStack(Items.PLAYER_HEAD)
-	.also { it.setSkullOwner(uuid, url) }
+fun createSkullItem(uuid: UUID, url: String) = LazyItemStack.build(Items.PLAYER_HEAD) { setSkullOwner(uuid, url) }
 
-fun ItemStack.setSkullOwner(uuid: UUID, url: String) {
+fun DataComponentMutator.setSkullOwner(uuid: UUID, url: String) {
 	assert(this.item == Items.PLAYER_HEAD)
 	val gameProfile = GameProfile(
 		uuid, "nea89", createSkullTextures(

--- a/src/main/kotlin/util/skyblock/AbilityUtils.kt
+++ b/src/main/kotlin/util/skyblock/AbilityUtils.kt
@@ -5,6 +5,8 @@ import net.minecraft.world.item.ItemStack
 import net.minecraft.network.chat.Component
 import moe.nea.firmament.util.ErrorUtil
 import moe.nea.firmament.util.directLiteralStringContent
+import moe.nea.firmament.util.mc.DataComponentAccessor
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.parseShortNumber
 import moe.nea.firmament.util.parseTimePattern
@@ -132,7 +134,7 @@ object AbilityUtils {
 	}
 
 	// TODO: memoize
-	fun getAbilities(itemStack: ItemStack): List<ItemAbility> {
+	fun getAbilities(itemStack: DataComponentAccessor): List<ItemAbility> {
 		return getAbilities(itemStack.loreAccordingToNbt)
 	}
 

--- a/src/main/kotlin/util/skyblock/ItemType.kt
+++ b/src/main/kotlin/util/skyblock/ItemType.kt
@@ -1,6 +1,7 @@
 package moe.nea.firmament.util.skyblock
 
 import net.minecraft.world.item.ItemStack
+import moe.nea.firmament.util.mc.DataComponentAccessor
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.petData
 
@@ -18,7 +19,7 @@ data class ItemType private constructor(val name: String) {
 				?.let(::ofName)
 		}
 
-		fun fromItemStack(itemStack: ItemStack): ItemType? {
+		fun fromItemStack(itemStack: DataComponentAccessor): ItemType? {
 			if (itemStack.petData != null)
 				return PET
 			for (loreLine in itemStack.loreAccordingToNbt) {

--- a/src/main/kotlin/util/skyblock/Rarity.kt
+++ b/src/main/kotlin/util/skyblock/Rarity.kt
@@ -13,6 +13,8 @@ import net.minecraft.network.chat.Component
 import net.minecraft.ChatFormatting
 import moe.nea.firmament.util.StringUtil.words
 import moe.nea.firmament.util.collections.lastNotNullOfOrNull
+import moe.nea.firmament.util.mc.DataComponentAccessor
+import moe.nea.firmament.util.mc.DataComponentMutator
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.petData
 import moe.nea.firmament.util.unformattedString
@@ -82,11 +84,11 @@ enum class Rarity(vararg altNames: String) {
 			return entries.getOrNull(tier)
 		}
 
-		fun fromItem(itemStack: ItemStack): Rarity? {
+		fun fromItem(itemStack: DataComponentAccessor): Rarity? {
 			return fromLore(itemStack.loreAccordingToNbt) ?: fromPetItem(itemStack)
 		}
 
-		fun fromPetItem(itemStack: ItemStack): Rarity? =
+		fun fromPetItem(itemStack: DataComponentAccessor): Rarity? =
 			itemStack.petData?.tier?.let(::fromNeuRepo)
 
 		fun fromLore(lore: List<Component>): Rarity? =

--- a/src/main/kotlin/util/skyblock/SBItemUtil.kt
+++ b/src/main/kotlin/util/skyblock/SBItemUtil.kt
@@ -1,14 +1,17 @@
 package moe.nea.firmament.util.skyblock
 
-import net.minecraft.world.item.ItemStack
+import moe.nea.firmament.util.mc.DataComponentAccessor
+import moe.nea.firmament.util.mc.RequiresComponents
 import moe.nea.firmament.util.mc.loreAccordingToNbt
+import moe.nea.firmament.util.renderingName
 import moe.nea.firmament.util.unformattedString
 
 object SBItemUtil {
-	fun ItemStack.getSearchName(): String {
-		val name = this.hoverName.unformattedString
+	@RequiresComponents
+	fun DataComponentAccessor.getSearchName(): String {
+		val name = this.renderingName.unformattedString
 		if (name.contains("Enchanted Book")) {
-			val enchant = loreAccordingToNbt.firstOrNull()?.unformattedString
+			val enchant = this.loreAccordingToNbt.firstOrNull()?.unformattedString
 			if (enchant != null) return enchant
 		}
 		if (name.startsWith("[Lvl")) {

--- a/src/main/kotlin/util/skyblock/SackUtil.kt
+++ b/src/main/kotlin/util/skyblock/SackUtil.kt
@@ -15,6 +15,7 @@ import moe.nea.firmament.util.SHORT_NUMBER_FORMAT
 import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ProfileSpecificDataHolder
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.iterableView
 import moe.nea.firmament.util.mc.loreAccordingToNbt
@@ -50,19 +51,19 @@ object SackUtil {
 		if (!screen.title.unformattedString.endsWith(" Sack")) return
 		val inv = screen.menu?.container ?: return
 		if (inv.containerSize < 18) return
-		val backSlot = inv.getItem(inv.containerSize - 5)
+		val backSlot = inv.getItem(inv.containerSize - 5).accessor()
 		if (backSlot.displayNameAccordingToNbt.unformattedString != "Go Back") return
 		if (backSlot.loreAccordingToNbt.map { it.unformattedString } != listOf("To Sack of Sacks")) return
 		for (itemStack in inv.iterableView) {
 			// TODO: handle runes and gemstones
-			val stored = itemStack.loreAccordingToNbt.firstNotNullOfOrNull {
+			val stored = itemStack.accessor().loreAccordingToNbt.firstNotNullOfOrNull {
 				storedRegex.useMatch(it.unformattedString) {
 					val stored = parseShortNumber(group("stored")).toLong()
 					val max = parseShortNumber(group("max")).toLong()
 					stored
 				}
 			} ?: continue
-			val itemId = itemStack.skyBlockId ?: continue
+			val itemId = itemStack.accessor().skyBlockId ?: continue
 			items[itemId] = stored
 		}
 		Store.markDirty()

--- a/src/main/kotlin/util/skyblock/ScreenIdentification.kt
+++ b/src/main/kotlin/util/skyblock/ScreenIdentification.kt
@@ -2,6 +2,7 @@ package moe.nea.firmament.util.skyblock
 
 import net.minecraft.client.gui.screens.Screen
 import net.minecraft.client.gui.screens.inventory.ContainerScreen
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 import moe.nea.firmament.util.unformattedString
@@ -27,10 +28,12 @@ enum class ScreenType(val detector: (Screen) -> Boolean) {
 		it is ContainerScreen && (
 			it.menu.getSlot(it.menu.rowCount * 9 - 4)
 				.item
+				.accessor()
 				.displayNameAccordingToNbt
 				.unformattedString == "Manage Orders"
 				|| it.menu.getSlot(it.menu.rowCount * 9 - 5)
 				.item
+				.accessor()
 				.loreAccordingToNbt
 				.any {
 					it.unformattedString == "To Bazaar"

--- a/src/test/kotlin/testutil/ItemResources.kt
+++ b/src/test/kotlin/testutil/ItemResources.kt
@@ -18,6 +18,7 @@ import net.minecraft.network.chat.ComponentSerialization
 import moe.nea.firmament.features.debug.ExportedTestConstantMeta
 import moe.nea.firmament.test.FirmTestBootstrap
 import moe.nea.firmament.util.MC
+import moe.nea.firmament.util.mc.LazyItemStack
 import moe.nea.firmament.util.mc.MCTabListAPI
 
 object ItemResources {
@@ -83,11 +84,11 @@ object ItemResources {
 		).getOrThrow { IllegalStateException("Could not load test chat '$name': $it") }
 	}
 
-	fun loadItem(name: String): ItemStack {
+	fun loadItem(name: String): LazyItemStack {
 		try {
 			//MC.currentOrDefaultRegistries.get(ResourceKey.create(Registries.ITEM, Identifier.withDefaultNamespace("diamond")))
 			val itemNbt = loadSNbt("testdata/items/$name.snbt")
-			return ItemStack.CODEC.parse(getNbtOps(), tryMigrateNbt(itemNbt, References.ITEM_STACK)).orThrow
+			return LazyItemStack.CODEC.parse(getNbtOps(), tryMigrateNbt(itemNbt, References.ITEM_STACK)).orThrow
 		} catch (ex: Exception) {
 			throw RuntimeException("Could not load item resource '$name'", ex)
 		}

--- a/src/texturePacks/java/moe/nea/firmament/features/texturepack/CustomGlobalArmorOverrides.kt
+++ b/src/texturePacks/java/moe/nea/firmament/features/texturepack/CustomGlobalArmorOverrides.kt
@@ -28,6 +28,7 @@ import moe.nea.firmament.features.texturepack.CustomGlobalTextures.logger
 import moe.nea.firmament.util.IdentifierSerializer
 import moe.nea.firmament.util.collections.WeakCache
 import moe.nea.firmament.util.intoOptional
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.skyBlockId
 
 object CustomGlobalArmorOverrides {
@@ -99,7 +100,7 @@ object CustomGlobalArmorOverrides {
 	// Then also re add this to the cache clearing function
 	val overrideCache =
 		WeakCache.dontMemoize<ItemStack, EquipmentSlot, Optional<Equippable>>("ArmorOverrides") { stack, slot ->
-			val id = stack.skyBlockId ?: return@dontMemoize Optional.empty()
+			val id = stack.accessor().skyBlockId ?: return@dontMemoize Optional.empty()
 			val override = overrides[id.neuItem] ?: return@dontMemoize Optional.empty()
 			for (suboverride in override.overrides) {
 				if (suboverride.predicate.test(stack)) {

--- a/src/texturePacks/java/moe/nea/firmament/features/texturepack/CustomSkyBlockTextures.kt
+++ b/src/texturePacks/java/moe/nea/firmament/features/texturepack/CustomSkyBlockTextures.kt
@@ -18,6 +18,7 @@ import moe.nea.firmament.features.debug.PowerUserTools
 import moe.nea.firmament.util.collections.WeakCache
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.decodeProfileTextureProperty
 import moe.nea.firmament.util.skyBlockId
 
@@ -74,7 +75,7 @@ object CustomSkyBlockTextures {
 	@Subscribe
 	fun onCustomModelId(it: CustomItemModelEvent) {
 		if (!TConfig.enabled) return
-		val id = it.itemStack.skyBlockId ?: return
+		val id = it.itemStack.accessor().skyBlockId ?: return
 		it.overrideIfEmpty(Identifier.fromNamespaceAndPath("firmskyblock", id.identifier.path))
 	}
 

--- a/src/texturePacks/java/moe/nea/firmament/features/texturepack/predicates/DisplayNamePredicate.kt
+++ b/src/texturePacks/java/moe/nea/firmament/features/texturepack/predicates/DisplayNamePredicate.kt
@@ -6,11 +6,12 @@ import moe.nea.firmament.features.texturepack.FirmamentModelPredicate
 import moe.nea.firmament.features.texturepack.FirmamentModelPredicateParser
 import moe.nea.firmament.features.texturepack.StringMatcher
 import net.minecraft.world.item.ItemStack
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.displayNameAccordingToNbt
 
 data class DisplayNamePredicate(val stringMatcher: StringMatcher) : FirmamentModelPredicate {
     override fun test(stack: ItemStack): Boolean {
-        val display = stack.displayNameAccordingToNbt
+        val display = stack.accessor().displayNameAccordingToNbt
         return stringMatcher.matches(display)
     }
 

--- a/src/texturePacks/java/moe/nea/firmament/features/texturepack/predicates/ExtraAttributesPredicate.kt
+++ b/src/texturePacks/java/moe/nea/firmament/features/texturepack/predicates/ExtraAttributesPredicate.kt
@@ -19,6 +19,7 @@ import net.minecraft.nbt.LongTag
 import net.minecraft.nbt.ShortTag
 import moe.nea.firmament.util.extraAttributes
 import moe.nea.firmament.util.mc.NbtPrism
+import moe.nea.firmament.util.mc.accessor
 
 fun interface NbtMatcher {
 	fun matches(nbt: Tag): Boolean
@@ -234,7 +235,7 @@ data class ExtraAttributesPredicate(
 	}
 
 	override fun test(stack: ItemStack): Boolean {
-		return path.access(stack.extraAttributes)
+		return path.access(stack.accessor().extraAttributes)
 			.any { matcher.matches(it) }
 	}
 }

--- a/src/texturePacks/java/moe/nea/firmament/features/texturepack/predicates/LorePredicate.kt
+++ b/src/texturePacks/java/moe/nea/firmament/features/texturepack/predicates/LorePredicate.kt
@@ -6,6 +6,7 @@ import moe.nea.firmament.features.texturepack.FirmamentModelPredicate
 import moe.nea.firmament.features.texturepack.FirmamentModelPredicateParser
 import moe.nea.firmament.features.texturepack.StringMatcher
 import net.minecraft.world.item.ItemStack
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.mc.loreAccordingToNbt
 
 class LorePredicate(val matcher: StringMatcher) : FirmamentModelPredicate {
@@ -16,7 +17,7 @@ class LorePredicate(val matcher: StringMatcher) : FirmamentModelPredicate {
     }
 
     override fun test(stack: ItemStack): Boolean {
-        val lore = stack.loreAccordingToNbt
+        val lore = stack.accessor().loreAccordingToNbt
         return lore.any { matcher.matches(it) }
     }
 }

--- a/src/texturePacks/java/moe/nea/firmament/features/texturepack/predicates/PetPredicate.kt
+++ b/src/texturePacks/java/moe/nea/firmament/features/texturepack/predicates/PetPredicate.kt
@@ -9,6 +9,7 @@ import moe.nea.firmament.features.texturepack.RarityMatcher
 import moe.nea.firmament.features.texturepack.StringMatcher
 import net.minecraft.world.item.ItemStack
 import moe.nea.firmament.repo.ExpLadders
+import moe.nea.firmament.util.mc.accessor
 import moe.nea.firmament.util.petData
 
 data class PetPredicate(
@@ -20,7 +21,7 @@ data class PetPredicate(
 ) : FirmamentModelPredicate {
 
     override fun test(stack: ItemStack): Boolean {
-        val petData = stack.petData ?: return false
+        val petData = stack.accessor().petData ?: return false
         if (petId != null) {
             if (!petId.matches(petData.type)) return false
         }


### PR DESCRIPTION
Fixes #2340

Possible points of contentions:

- Should there be _more_ convenience for `.accessor()`
- Should ItemStack implement `DataComponentAccessor` directly (can be done through mixin and in devenv through a jar processor)
- How should WeakCaches handle these accessors
- Should the class hierarchy of this be more lean
- Should there be a type that is more transparently a specific ItemStack
- If LazyItemStack is immutable then we can be a bit more lazy about how we decay back into an itemstack, i think? unsure
- We very explicitly lose _fallback_ components. So things like getting that an apple (for example) is a food item gets deliberately lost. This could be good or bad, and these discarded components could have repo implications that i should check (do the item stack exports look correct, not missing any data, we have done a similar discarding in the past so i am not toooo worried) (cc @jani270)
