### PR TITLE
fix: pet menu title not being detected

### DIFF
--- a/src/main/kotlin/features/inventory/PetFeatures.kt
+++ b/src/main/kotlin/features/inventory/PetFeatures.kt
@@ -64,7 +64,7 @@ object PetFeatures {
 		}
 	}
 
-	private val petMenuTitle = "Pets(?: \\([0-9]+/[0-9]+\\))?".toPattern()
+	private val petMenuTitle = "(?:\\([0-9]+/[0-9]+\\)\\s)?Pets".toPattern()
 	private val autopetPattern =
 		"§cAutopet §eequipped your §7\\[Lvl (\\d{1,3})\\] §([fa956d])([\\w\\s]+)§e! §aVIEW RULE".toPattern()
 	private val petItemPattern = "§aYour pet is now holding (§[fa956d][\\w\\s]+)§a.".toPattern()


### PR DESCRIPTION
Fixes #2328

<!--

Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->


## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [x] I have not used AI to author code
- [ ] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
