### PR TITLE
REI Recipe renderer: revert icon changes

### DIFF
--- a/src/compat/rei/java/moe/nea/firmament/compat/rei/recipes/GenericREIRecipeCategory.kt
+++ b/src/compat/rei/java/moe/nea/firmament/compat/rei/recipes/GenericREIRecipeCategory.kt
@@ -10,7 +10,6 @@ import me.shedaniel.rei.api.client.registry.display.DisplayRegistry
 import me.shedaniel.rei.api.common.category.CategoryIdentifier
 import me.shedaniel.rei.api.common.util.EntryStacks
 import net.minecraft.network.chat.Component
-import net.minecraft.world.item.Items
 import moe.nea.firmament.compat.rei.REIRecipeLayouter
 import moe.nea.firmament.compat.rei.neuDisplayGeneratorWithItem
 import moe.nea.firmament.repo.SBItemStack
@@ -42,7 +41,7 @@ class GenericREIRecipeCategory<T : NEURecipe>(
 	}
 
 	override fun getIcon(): Renderer? {
-		return EntryStacks.of { Items.ANVIL }
+		return EntryStacks.of(renderer.icon)
 	}
 
 	override fun setupDisplay(display: GenericRecipe<T>, bounds: Rectangle): List<Widget> {

--- a/src/main/kotlin/repo/recipes/GenericRecipeRenderer.kt
+++ b/src/main/kotlin/repo/recipes/GenericRecipeRenderer.kt
@@ -4,14 +4,14 @@ import io.github.moulberry.repo.NEURepository
 import me.shedaniel.math.Rectangle
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.Identifier
-import net.minecraft.world.item.ItemStackTemplate
+import net.minecraft.world.item.ItemStack
 import moe.nea.firmament.repo.SBItemStack
 
 interface GenericRecipeRenderer<T : Any> {
 	fun render(recipe: T, bounds: Rectangle, layouter: RecipeLayouter, mainItem: SBItemStack?)
 	fun getInputs(recipe: T): Collection<SBItemStack>
 	fun getOutputs(recipe: T): Collection<SBItemStack>
-	val icon: ItemStackTemplate
+	val icon: ItemStack
 	val title: Component
 	val identifier: Identifier
 	fun findAllRecipes(neuRepository: NEURepository): Iterable<T>

--- a/src/main/kotlin/repo/recipes/SBCraftingRecipeRenderer.kt
+++ b/src/main/kotlin/repo/recipes/SBCraftingRecipeRenderer.kt
@@ -8,12 +8,8 @@ import net.minecraft.world.level.block.Blocks
 import net.minecraft.world.item.ItemStack
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.Identifier
-import net.minecraft.world.item.ItemStackTemplate
-import net.minecraft.world.item.Items
 import moe.nea.firmament.Firmament
-import moe.nea.firmament.repo.ExpensiveItemCacheApi
 import moe.nea.firmament.repo.SBItemStack
-import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.tr
 
 object SBCraftingRecipeRenderer : GenericRecipeRenderer<NEUCraftingRecipe> {
@@ -66,7 +62,7 @@ object SBCraftingRecipeRenderer : GenericRecipeRenderer<NEUCraftingRecipe> {
 		return neuRepository.items.items.values.flatMap { it.recipes }.filterIsInstance<NEUCraftingRecipe>()
 	}
 
-	override val icon: ItemStackTemplate = ItemStackTemplate(Items.CRAFTING_TABLE)
+	override val icon: ItemStack by lazy { ItemStack(Blocks.CRAFTING_TABLE) }
 	override val title: Component = tr("firmament.category.crafting", "SkyBlock Crafting")
 	override val identifier: Identifier = Firmament.identifier("crafting_recipe")
 }

--- a/src/main/kotlin/repo/recipes/SBEssenceUpgradeRecipeRenderer.kt
+++ b/src/main/kotlin/repo/recipes/SBEssenceUpgradeRecipeRenderer.kt
@@ -5,8 +5,6 @@ import me.shedaniel.math.Rectangle
 import net.minecraft.world.item.ItemStack
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.Identifier
-import net.minecraft.world.item.ItemStackTemplate
-import net.minecraft.world.item.Items
 import moe.nea.firmament.Firmament
 import moe.nea.firmament.repo.EssenceRecipeProvider
 import moe.nea.firmament.repo.ExpensiveItemCacheApi
@@ -63,7 +61,8 @@ object SBEssenceUpgradeRecipeRenderer : GenericRecipeRenderer<EssenceRecipeProvi
 		return listOfNotNull(SBItemStack(recipe.itemId))
 	}
 
-	override val icon: ItemStackTemplate = ItemStackTemplate(Items.WITHER_SKELETON_SKULL)
+	@OptIn(ExpensiveItemCacheApi::class)
+	override val icon: ItemStack by lazy { SBItemStack(SkyblockId(("ESSENCE_WITHER"))).asImmutableItemStack() }
 	override val title: Component = tr("firmament.category.essence", "Essence Upgrades")
 	override val identifier: Identifier = Firmament.identifier("essence_upgrade")
 	override fun findAllRecipes(neuRepository: NEURepository): Iterable<EssenceRecipeProvider.EssenceUpgradeRecipe> {

--- a/src/main/kotlin/repo/recipes/SBForgeRecipeRenderer.kt
+++ b/src/main/kotlin/repo/recipes/SBForgeRecipeRenderer.kt
@@ -11,13 +11,8 @@ import net.minecraft.world.level.block.Blocks
 import net.minecraft.world.item.ItemStack
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.Identifier
-import net.minecraft.world.item.Item
-import net.minecraft.world.item.ItemStackTemplate
-import net.minecraft.world.item.Items
 import moe.nea.firmament.Firmament
-import moe.nea.firmament.repo.ExpensiveItemCacheApi
 import moe.nea.firmament.repo.SBItemStack
-import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.tr
 
 object SBForgeRecipeRenderer : GenericRecipeRenderer<NEUForgeRecipe> {
@@ -79,7 +74,7 @@ object SBForgeRecipeRenderer : GenericRecipeRenderer<NEUForgeRecipe> {
 		return listOfNotNull(SBItemStack(recipe.outputStack))
 	}
 
-	override val icon: ItemStackTemplate = ItemStackTemplate(Items.ANVIL)
+	override val icon: ItemStack by lazy { ItemStack(Blocks.FURNACE) }
 	override val title: Component = tr("firmament.category.forge", "Forge Recipes")
 	override val identifier: Identifier = Firmament.identifier("forge_recipe")
 

--- a/src/main/kotlin/repo/recipes/SBReforgeRecipeRenderer.kt
+++ b/src/main/kotlin/repo/recipes/SBReforgeRecipeRenderer.kt
@@ -8,8 +8,7 @@ import net.minecraft.resources.Identifier
 import net.minecraft.world.entity.EntitySpawnReason
 import net.minecraft.world.entity.EntityType
 import net.minecraft.world.entity.npc.villager.VillagerProfession
-import net.minecraft.world.item.ItemStackTemplate
-import net.minecraft.world.item.Items
+import net.minecraft.world.item.ItemStack
 import moe.nea.firmament.Firmament
 import moe.nea.firmament.gui.entity.EntityRenderer
 import moe.nea.firmament.repo.ExpensiveItemCacheApi
@@ -151,7 +150,8 @@ object SBReforgeRecipeRenderer : GenericRecipeRenderer<Reforge> {
 		return listOf()
 	}
 
-	override val icon: ItemStackTemplate = ItemStackTemplate(Items.ANVIL)
+	@OptIn(ExpensiveItemCacheApi::class)
+	override val icon: ItemStack by lazy { SBItemStack(SkyBlockItems.REFORGE_ANVIL).asImmutableItemStack() }
 	override val title: Component
 		get() = tr("firmament.recipecategory.reforge", "Reforge")
 	override val identifier: Identifier

--- a/src/main/kotlin/repo/recipes/SBReforgeRecipeRenderer.kt
+++ b/src/main/kotlin/repo/recipes/SBReforgeRecipeRenderer.kt
@@ -9,6 +9,7 @@ import net.minecraft.world.entity.EntitySpawnReason
 import net.minecraft.world.entity.EntityType
 import net.minecraft.world.entity.npc.villager.VillagerProfession
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.level.block.Blocks
 import moe.nea.firmament.Firmament
 import moe.nea.firmament.gui.entity.EntityRenderer
 import moe.nea.firmament.repo.ExpensiveItemCacheApi
@@ -150,8 +151,7 @@ object SBReforgeRecipeRenderer : GenericRecipeRenderer<Reforge> {
 		return listOf()
 	}
 
-	@OptIn(ExpensiveItemCacheApi::class)
-	override val icon: ItemStack by lazy { SBItemStack(SkyBlockItems.REFORGE_ANVIL).asImmutableItemStack() }
+	override val icon: ItemStack by lazy { ItemStack(Blocks.ANVIL) }
 	override val title: Component
 		get() = tr("firmament.recipecategory.reforge", "Reforge")
 	override val identifier: Identifier


### PR DESCRIPTION
Reverting some other random changes I made while trying to get things launching.

I'm assuming #2342 is supposed to be used in someway here?
if not, this PR restores the original behavior while also not crashing the game on launch.
Also replaced the forge icon with a furnace because reforge and forge both being anvils is kind of confusing.

<!--


Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->


## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [x] I have not used AI to author code
- [ ] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
