### PR TITLE
feat: add patch for owo-lib REI plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -204,6 +204,7 @@ val irisSourceSet = createIsolatedSourceSet("iris")
 val customTexturesSourceSet = createIsolatedSourceSet("texturePacks", "texturePacks")
 val apiSourceSet = createIsolatedSourceSet("api", "api", inheritsFromMain = false, enableKsp = false)
 val jarvisSourceSet = createIsolatedSourceSet("jarvis", "vendor/jarvis", inheritsFromMain = false, enableKsp = false)
+val owolibSourceSet = createIsolatedSourceSet("owolib")
 
 dependencies {
 	// Minecraft dependencies
@@ -268,6 +269,8 @@ dependencies {
 	val reiDeps = libs.rei
 	(reiSourceSet.implementationConfigurationName)(reiDeps.api)
 	(reiSourceSet.implementationConfigurationName)(reiDeps.fabric)
+	(owolibSourceSet.implementationConfigurationName)(reiDeps.api)
+	(owolibSourceSet.implementationConfigurationName)(libs.owolib)
 	implementation(libs.repoparser)
 	shadowMe(libs.repoparser)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,6 +86,9 @@ classtransform = "1.14.1"
 # Update from https://mvnrepository.com/artifact/org.ow2.asm/asm/
 asm = "9.9.1"
 
+# Update from https://maven.wispforest.io/#/releases/io/wispforest/owo-lib
+owolib = "0.13.0+26.1"
+
 [libraries]
 minecraft = { module = "com.mojang:minecraft", version.ref = "minecraft" }
 fabric_loader = { module = "net.fabricmc:fabric-loader", version.ref = "fabric_loader" }
@@ -129,6 +132,8 @@ classTransform-mixinsTranslator = { module = "net.lenni0451.classtransform:mixin
 classTransform-core = { module = "net.lenni0451.classtransform:core", version.ref = "classtransform" }
 
 asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
+
+owolib = { module = "io.wispforest:owo-lib", version.ref = "owolib" }
 
 [plugins]
 kotlin_jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/gradle/repositories.properties
+++ b/gradle/repositories.properties
@@ -19,10 +19,11 @@ azureaaronReleases=https://maven.azureaaron.net/releases/
 curseMaven=https://www.cursemaven.com/
 isxander=https://maven.isxander.dev/releases/
 parchmentMc=https://maven.parchmentmc.org/
+wispforest=https://maven.wispforest.io/releases/
 # jitpack can cause issues so whitelist any relevant jitpack files in repo.nea.moe/mirror/ and pull from there
 # if you do not have access to that maven, please ask nea to whitelist the files for you and uncomment this jitpack in
 # the meantime
-# jitpack=https://jitpack.io/
+jitpack=https://jitpack.io/
 
 # arguably all of these repos should be mirrored through my servers. that is a later TODO.
 

--- a/src/compat/owolib/java/moe/nea/firmament/compat/owolib/Compat.kt
+++ b/src/compat/owolib/java/moe/nea/firmament/compat/owolib/Compat.kt
@@ -1,0 +1,12 @@
+package moe.nea.firmament.compat.rei
+
+import net.fabricmc.loader.api.FabricLoader
+import moe.nea.firmament.util.compatloader.CompatMeta
+import moe.nea.firmament.util.compatloader.ICompatMeta
+
+@CompatMeta
+object Compat : ICompatMeta {
+	override fun shouldLoad(): Boolean {
+		return FabricLoader.getInstance().isModLoaded("owo")
+	}
+}

--- a/src/compat/owolib/java/moe/nea/firmament/mixins/OwoReiPluginPatch.java
+++ b/src/compat/owolib/java/moe/nea/firmament/mixins/OwoReiPluginPatch.java
@@ -1,0 +1,12 @@
+package moe.nea.firmament.mixins.owolib;
+
+import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
+import org.spongepowered.asm.mixin.Mixin;
+import moe.nea.firmament.util.compatloader.CompatLoader;
+
+@CompatLoader.RequireMod(modId = "owo", minVersion = "0.13.0", maxVersion = "0.13.0")
+@CompatLoader.RequireMod(modId = "roughlyenoughitems")
+@Mixin(targets = "io.wispforest.owo.compat.rei.OwoReiPlugin")
+public abstract class OwoReiPluginPatch implements REIClientPlugin {
+	// Dummy mixin to add the missing interface implementation and prevent the game from crashing
+}

--- a/src/compat/owolib/java/moe/nea/firmament/mixins/compat/owolib/OwoReiPluginPatch.java
+++ b/src/compat/owolib/java/moe/nea/firmament/mixins/compat/owolib/OwoReiPluginPatch.java
@@ -1,4 +1,4 @@
-package moe.nea.firmament.mixins.owolib;
+package moe.nea.firmament.mixins.compat.owolib;
 
 import me.shedaniel.rei.api.client.plugins.REIClientPlugin;
 import org.spongepowered.asm.mixin.Mixin;

--- a/src/main/kotlin/util/compatloader/CompatLoader.kt
+++ b/src/main/kotlin/util/compatloader/CompatLoader.kt
@@ -2,6 +2,7 @@ package moe.nea.firmament.util.compatloader
 
 import java.util.ServiceLoader
 import net.fabricmc.loader.api.FabricLoader
+import net.fabricmc.loader.api.Version
 import kotlin.reflect.KClass
 import kotlin.streams.asSequence
 import moe.nea.firmament.Firmament
@@ -42,9 +43,17 @@ open class CompatLoader<T : Any>(val kClass: Class<T>) {
 
 	fun checkRequiredModsPresent(type: Class<*>): Boolean {
 		val requiredMods = type.getAnnotationsByType(RequireMod::class.java)
-		return requiredMods.all { FabricLoader.getInstance().isModLoaded(it.modId) }
+		return requiredMods.all { mod ->
+			val minVersion = mod.minVersion.takeUnless { it.isEmpty() }?.let(Version::parse)
+			val maxVersion = mod.maxVersion.takeUnless { it.isEmpty() }?.let(Version::parse)
+
+			FabricLoader.getInstance().getModContainer(mod.modId).orElse(null)?.metadata?.let { metadata ->
+				(minVersion == null || metadata.version >= minVersion) &&
+					(maxVersion == null || metadata.version <= maxVersion)
+			} ?: false
+		}
 	}
 
 	@Repeatable
-	annotation class RequireMod(val modId: String)
+	annotation class RequireMod(val modId: String, val minVersion: String = "", val maxVersion: String = "")
 }


### PR DESCRIPTION
<!--


Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->
owo-lib is a library that several other popular mods depend on, but the maintainers seem to have disappeared, and the mod is registering a REI entrypoint that does *not* implement REIClientPlugin (it was shoddily commented out back when REI for 26.1 wasn't a thing yet), causing the game to crash if both are installed. This PR adds a small dummy mixin to fix this.

**Note:** Jitpack was uncommented for a transitive dependency of owo-lib (`com.github.kdl-org:kdl4j`). It should probably be whitelisted on the mirror instead.

## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [x] I have not used AI to author code
- [ ] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
