### PR TITLE
fix(SBEssenceUpgradeRecipeRenderer): return actual ItemStack

### DIFF
--- a/src/main/kotlin/repo/recipes/SBEssenceUpgradeRecipeRenderer.kt
+++ b/src/main/kotlin/repo/recipes/SBEssenceUpgradeRecipeRenderer.kt
@@ -3,6 +3,7 @@ package moe.nea.firmament.repo.recipes
 import io.github.moulberry.repo.NEURepository
 import me.shedaniel.math.Rectangle
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.Items
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.Identifier
 import moe.nea.firmament.Firmament
@@ -62,7 +63,9 @@ object SBEssenceUpgradeRecipeRenderer : GenericRecipeRenderer<EssenceRecipeProvi
 	}
 
 	@OptIn(ExpensiveItemCacheApi::class)
-	override val icon: ItemStack by lazy { SBItemStack(SkyblockId(("ESSENCE_WITHER"))).asImmutableItemStack() }
+	override val icon: ItemStack by lazy {
+		SBItemStack(SkyblockId(("ESSENCE_WITHER"))).asImmutableItemStack().maybeItemStack() ?: ItemStack(Items.PAINTING)
+	}
 	override val title: Component = tr("firmament.category.essence", "Essence Upgrades")
 	override val identifier: Identifier = Firmament.identifier("essence_upgrade")
 	override fun findAllRecipes(neuRepository: NEURepository): Iterable<EssenceRecipeProvider.EssenceUpgradeRecipe> {

--- a/src/main/kotlin/repo/recipes/SBEssenceUpgradeRecipeRenderer.kt
+++ b/src/main/kotlin/repo/recipes/SBEssenceUpgradeRecipeRenderer.kt
@@ -3,7 +3,6 @@ package moe.nea.firmament.repo.recipes
 import io.github.moulberry.repo.NEURepository
 import me.shedaniel.math.Rectangle
 import net.minecraft.world.item.ItemStack
-import net.minecraft.world.item.Items
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.Identifier
 import moe.nea.firmament.Firmament
@@ -12,6 +11,7 @@ import moe.nea.firmament.repo.ExpensiveItemCacheApi
 import moe.nea.firmament.repo.RepoManager
 import moe.nea.firmament.repo.SBItemStack
 import moe.nea.firmament.util.SkyblockId
+import moe.nea.firmament.util.mc.RequiresComponents
 import moe.nea.firmament.util.tr
 
 object SBEssenceUpgradeRecipeRenderer : GenericRecipeRenderer<EssenceRecipeProvider.EssenceUpgradeRecipe> {
@@ -62,9 +62,9 @@ object SBEssenceUpgradeRecipeRenderer : GenericRecipeRenderer<EssenceRecipeProvi
 		return listOfNotNull(SBItemStack(recipe.itemId))
 	}
 
-	@OptIn(ExpensiveItemCacheApi::class)
+	@OptIn(ExpensiveItemCacheApi::class, RequiresComponents::class)
 	override val icon: ItemStack by lazy {
-		SBItemStack(SkyblockId(("ESSENCE_WITHER"))).asImmutableItemStack().maybeItemStack() ?: ItemStack(Items.PAINTING)
+		SBItemStack(SkyblockId(("ESSENCE_WITHER"))).asImmutableItemStack().upgrade()
 	}
 	override val title: Component = tr("firmament.category.essence", "Essence Upgrades")
 	override val identifier: Identifier = Firmament.identifier("essence_upgrade")


### PR DESCRIPTION
<!--


Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->
Fixes a build failure caused by a method expected to return an `ItemStack` actually returning a `LazyItemStack`.

## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [x] I have not used AI to author code
- [ ] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
