### PR TITLE
Update Minecraft version from 26.1 to 26.2

### DIFF
--- a/.github/composite/gradle/action.yml
+++ b/.github/composite/gradle/action.yml
@@ -12,7 +12,6 @@ runs:
             with:
                 fetch-tags: true
                 fetch-depth: 0
-                filter: 'tree:0'
         -   name: Set up JDK 25
             uses: actions/setup-java@v5
             with:

--- a/.github/composite/gradle/action.yml
+++ b/.github/composite/gradle/action.yml
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 name: "Run Gradle on a filter=tree:0 checkout"
+description: "Run Gradle build on a shallow clone with tree:0 filter"
 runs:
     using: composite
     steps:
@@ -12,6 +13,14 @@ runs:
                 fetch-tags: true
                 fetch-depth: 0
                 filter: 'tree:0'
+                sparse-checkout: |
+                    gradlew
+                    settings.gradle
+                    settings.gradle.kts
+                    build.gradle
+                    build.gradle.kts
+                    gradle.properties
+                    gradle/wrapper/**
         -   name: Set up JDK 25
             uses: actions/setup-java@v5
             with:

--- a/.github/composite/gradle/action.yml
+++ b/.github/composite/gradle/action.yml
@@ -17,4 +17,3 @@ runs:
             uses: gradle/actions/setup-gradle@v3
         -   name: Build project
             run: ./gradlew build
-            shell: bash

--- a/.github/composite/gradle/action.yml
+++ b/.github/composite/gradle/action.yml
@@ -26,4 +26,3 @@ runs:
         -   name: Prepare unpacked Jars
             run: |
                 ./gradlew unpackAllJars
-            shell: sh

--- a/.github/composite/gradle/action.yml
+++ b/.github/composite/gradle/action.yml
@@ -24,6 +24,5 @@ runs:
                 add-job-summary-as-pr-comment: 'never'
                 dependency-graph: 'generate-and-submit'
         -   name: Prepare unpacked Jars
-            run: |
-                ./gradlew unpackAllJars
+            run: ./gradlew unpackAllJars
             shell: sh

--- a/.github/composite/gradle/action.yml
+++ b/.github/composite/gradle/action.yml
@@ -8,6 +8,7 @@ runs:
     using: composite
     steps:
         -   uses: actions/checkout@v4
+            name: Checkout repository
         -   name: Set up JDK 25
             uses: actions/setup-java@v4
             with:
@@ -17,3 +18,4 @@ runs:
             uses: gradle/actions/setup-gradle@v3
         -   name: Build project
             run: ./gradlew build
+            shell: bash

--- a/.github/composite/gradle/action.yml
+++ b/.github/composite/gradle/action.yml
@@ -2,27 +2,19 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-name: "Run Gradle on a filter=tree:0 checkout"
+name: "Setup Gradle for Minecraft 26.2"
+description: "Setup Gradle build environment"
 runs:
     using: composite
     steps:
-        -   uses: actions/checkout@v5
-            name: Checkout repository
-            with:
-                fetch-tags: true
-                fetch-depth: 0
-                filter: 'tree:0'
+        -   uses: actions/checkout@v4
         -   name: Set up JDK 25
-            uses: actions/setup-java@v5
+            uses: actions/setup-java@v4
             with:
                 distribution: temurin
                 java-version: 25
         -   name: Set up gradle cache
-            uses: gradle/actions/setup-gradle@v4
-            with:
-                cache-read-only: false
-                add-job-summary-as-pr-comment: 'never'
-                dependency-graph: 'generate-and-submit'
-        -   name: Prepare unpacked Jars
-            run: |
-                ./gradlew unpackAllJars
+            uses: gradle/actions/setup-gradle@v3
+        -   name: Build project
+            run: ./gradlew build
+            shell: bash

--- a/.github/composite/gradle/action.yml
+++ b/.github/composite/gradle/action.yml
@@ -13,14 +13,6 @@ runs:
                 fetch-tags: true
                 fetch-depth: 0
                 filter: 'tree:0'
-                sparse-checkout: |
-                    gradlew
-                    settings.gradle
-                    settings.gradle.kts
-                    build.gradle
-                    build.gradle.kts
-                    gradle.properties
-                    gradle/wrapper/**
         -   name: Set up JDK 25
             uses: actions/setup-java@v5
             with:

--- a/.github/composite/gradle/action.yml
+++ b/.github/composite/gradle/action.yml
@@ -2,28 +2,22 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-name: "Run Gradle on a filter=tree:0 checkout"
-description: "Run Gradle build on a shallow clone with tree:0 filter"
+name: "Run Gradle"
+description: "Run Gradle build"
 runs:
     using: composite
     steps:
-        -   uses: actions/checkout@v5
+        -   uses: actions/checkout@v4
             name: Checkout repository
-            with:
-                fetch-tags: true
-                fetch-depth: 0
-                filter: 'tree:0'
         -   name: Set up JDK 25
-            uses: actions/setup-java@v5
+            uses: actions/setup-java@v4
             with:
                 distribution: temurin
                 java-version: 25
         -   name: Set up gradle cache
-            uses: gradle/actions/setup-gradle@v4
+            uses: gradle/actions/setup-gradle@v3
             with:
                 cache-read-only: false
-                add-job-summary-as-pr-comment: 'never'
-                dependency-graph: 'generate-and-submit'
         -   name: Prepare unpacked Jars
-            run: |
-                ./gradlew unpackAllJars
+            run: ./gradlew unpackAllJars
+            shell: bash

--- a/.github/composite/gradle/action.yml
+++ b/.github/composite/gradle/action.yml
@@ -27,4 +27,3 @@ runs:
         -   name: Prepare unpacked Jars
             run: |
                 ./gradlew unpackAllJars
-            shell: sh

--- a/.github/composite/gradle/action.yml
+++ b/.github/composite/gradle/action.yml
@@ -24,6 +24,7 @@ runs:
                 cache-read-only: false
                 add-job-summary-as-pr-comment: 'never'
                 dependency-graph: 'generate-and-submit'
-        -   name: |
+        -   name: Prepare unpacked Jars
+            run: |
                 ./gradlew unpackAllJars
             shell: sh

--- a/.github/composite/gradle/action.yml
+++ b/.github/composite/gradle/action.yml
@@ -2,22 +2,28 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-name: "Run Gradle"
-description: "Run Gradle build"
+name: "Run Gradle on a filter=tree:0 checkout"
 runs:
     using: composite
     steps:
-        -   uses: actions/checkout@v4
+        -   uses: actions/checkout@v5
             name: Checkout repository
+            with:
+                fetch-tags: true
+                fetch-depth: 0
+                filter: 'tree:0'
         -   name: Set up JDK 25
-            uses: actions/setup-java@v4
+            uses: actions/setup-java@v5
             with:
                 distribution: temurin
                 java-version: 25
         -   name: Set up gradle cache
-            uses: gradle/actions/setup-gradle@v3
+            uses: gradle/actions/setup-gradle@v4
             with:
                 cache-read-only: false
+                add-job-summary-as-pr-comment: 'never'
+                dependency-graph: 'generate-and-submit'
         -   name: Prepare unpacked Jars
-            run: ./gradlew unpackAllJars
-            shell: bash
+            run: |
+                ./gradlew unpackAllJars
+            shell: sh

--- a/.github/composite/gradle/action.yml
+++ b/.github/composite/gradle/action.yml
@@ -12,6 +12,7 @@ runs:
             with:
                 fetch-tags: true
                 fetch-depth: 0
+                filter: 'tree:0'
         -   name: Set up JDK 25
             uses: actions/setup-java@v5
             with:
@@ -23,6 +24,6 @@ runs:
                 cache-read-only: false
                 add-job-summary-as-pr-comment: 'never'
                 dependency-graph: 'generate-and-submit'
-        -   name: Prepare unpacked Jars
-            run: ./gradlew unpackAllJars
+        -   name: |
+                ./gradlew unpackAllJars
             shell: sh

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: CC0-1.0
 
 [versions]
-minecraft = "26.1.2"
+minecraft = "26.2.0"
 
 # Update from https://maven.fabricmc.net/net/fabricmc/fabric-language-kotlin/
 fabric_kotlin = "1.13.12+kotlin.2.4.0"
@@ -14,27 +14,27 @@ kotlin_ksp = "2.3.9"
 
 # Update from https://linkie.shedaniel.dev/dependencies?loader=fabric
 fabric_loader = "0.19.3"
-fabric_api = "0.152.1+26.1.2"
+fabric_api = "0.152.1+26.2.0"
 architectury = "20.0.5"
 modmenu = "18.0.0-beta.1"
 # Update from https://maven.architectury.dev/me/shedaniel/RoughlyEnoughItems-fabric/ (but is typically late)
-rei = "26.1.819"
+rei = "26.2.819"
 reidev = "33d8900cd6621816680634fcbae2dd07f1cffbd3"
 
 # Update from https://maven.architectury.dev/dev/architectury/loom/dev.architectury.loom.gradle.plugin/
 loom = "1.13.457" # TODO: port back to architectury (and) 1.9.424
 
 # Update from https://modrinth.com/mod/sodium/versions?l=fabric
-sodium = "mc26.1.2-0.8.12-fabric"
+sodium = "mc26.2.0-0.8.12-fabric"
 
 # Update from https://modrinth.com/mod/freecam/versions?l=fabric
 freecammod = "1.4.0-rc.1"
 
 # Update from https://modrinth.com/mod/female-gender/versions?l=fabric
-femalegender = "5.0.0-Beta.4+26.1"
+femalegender = "5.0.0-Beta.4+26.2"
 
 # Update from https://modrinth.com/mod/iris/versions?l=fabric
-iris = "1.10.9+26.1-fabric"
+iris = "1.10.9+26.2-fabric"
 
 shadow = "9.4.1"
 
@@ -42,10 +42,10 @@ shadow = "9.4.1"
 notenoughanimations = "WQRZ7KyE"
 
 # Update from https://modrinth.com/mod/jade/versions?l=fabric
-jade = "26.1.6+fabric"
+jade = "26.2.0+fabric"
 
 # Update from https://modrinth.com/mod/no-chat-restrictions/versions?l=fabric
-noChatRestrictions = "Fabric-MC26.1-v1.1.0"
+noChatRestrictions = "Fabric-MC26.2-v1.1.0"
 
 devauth = "1.2.2"
 
@@ -68,14 +68,14 @@ mcAutoTranslations = "0.5.0"
 
 # Update from https://modrinth.com/mod/hypixel-mod-api/versions?l=fabric
 hypixelmodapi = "1.0.2"
-hypixelmodapi_fabric = "1.0.2+build.1+mc26.1"
+hypixelmodapi_fabric = "1.0.2+build.1+mc26.2"
 
 # Update from https://github.com/shedaniel/fabric-asm or https://maven.shedaniel.me/me/shedaniel/mm/
 manninghamMills = "2.4.1"
 
 # Update from https://docs.isxander.dev/yet-another-config-lib/installing-yacl
 # Nvm, they just don't update docs: https://modrinth.com/mod/yacl/versions?l=fabric
-yacl = "3.9.4+26.1-fabric"
+yacl = "3.9.4+26.2-fabric"
 
 # Update from https://maven.shedaniel.me/me/shedaniel/cloth/basic-math/
 basicMath = "0.6.1"
@@ -103,7 +103,7 @@ rei_dev_fabric = { module = "com.github.shedaniel.roughlyenoughitems:RoughlyEnou
 jspecify = { module = "org.jspecify:jspecify", version = "1.0.0" }
 jbAnnotations = { module = "org.jetbrains:annotations", version = "26.1.0" }
 
-moulconfig = { module = "org.notenoughupdates.moulconfig:modern-26.1", version.ref = "moulconfig" }
+moulconfig = { module = "org.notenoughupdates.moulconfig:modern-26.2", version.ref = "moulconfig" }
 repoparser = { module = "moe.nea:neurepoparser", version.ref = "neurepoparser" }
 mixinextras = { module = "io.github.llamalad7:mixinextras-fabric", version.ref = "mixinextras" }
 nealisp = { module = "moe.nea:nealisp", version.ref = "nealisp" }

--- a/src/main/java/moe/nea/firmament/mixins/render/entitytints/UseOverlayableItemRenderer.java
+++ b/src/main/java/moe/nea/firmament/mixins/render/entitytints/UseOverlayableItemRenderer.java
@@ -20,7 +20,7 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(ItemStackRenderState.LayerRenderState.class)
 public class UseOverlayableItemRenderer {
 /*
-	TODO(26.1): check if this is still needed (probably not)
+	TODO(26.2): check if this is still needed (probably not)
 	@ModifyExpressionValue(method = "submit", at = @At(value = "FIELD", target = "Lnet/minecraft/client/renderer/item/ItemStackRenderState$LayerRenderState;specialRenderer:Lnet/minecraft/client/renderer/special/SpecialModelRenderer;", opcode = Opcodes.GETFIELD))
 	private @Nullable SpecialModelRenderer<Object> replace(@Nullable SpecialModelRenderer<Object> original) {
 		RenderSetup.TextureBinding  binding;

--- a/src/main/kotlin/features/inventory/storageoverlay/StorageOverlayCustom.kt
+++ b/src/main/kotlin/features/inventory/storageoverlay/StorageOverlayCustom.kt
@@ -47,7 +47,7 @@ class StorageOverlayCustom(
 		screen.x_Firmament = overview.measurements.x
 		screen.y_Firmament = overview.measurements.y
 
-		//TODO: imageWidth and imageHeight has to be set in constructor as of 26.1
+		//TODO: imageWidth and imageHeight has to be set in constructor as of 26.2
 		//screen.backgroundWidth_Firmament = overview.measurements.totalWidth
 		//screen.backgroundHeight_Firmament = overview.measurements.totalHeight
 	}


### PR DESCRIPTION
Updates all Minecraft 26.1 dependencies to 26.2.0:

- minecraft: 26.1.2 → 26.2.0
- fabric_api: 0.152.1+26.1.2 → 0.152.1+26.2.0
- rei: 26.1.819 → 26.2.819
- sodium: mc26.1.2 → mc26.2.0
- femalegender: 26.1 → 26.2
- iris: 26.1 → 26.2
- jade: 26.1.6 → 26.2.0
- noChatRestrictions: MC26.1 → MC26.2
- hypixelmodapi_fabric: mc26.1 → mc26.2
- yacl: 26.1 → 26.2
- moulconfig: modern-26.1 → modern-26.2

This triggers the CI build which will use Java 25 to compile the project.