### PR TITLE
fix: wardrobe keybinds title detection & enable keybinds for equipment wardrobe

### DIFF
--- a/src/main/kotlin/features/inventory/WardrobeKeybinds.kt
+++ b/src/main/kotlin/features/inventory/WardrobeKeybinds.kt
@@ -33,7 +33,7 @@ object WardrobeKeybinds {
 		if (event.screen !is AbstractContainerScreen<*>) return
 		if (event.isRepeat) return
 
-		val regex = Regex("Wardrobe \\([0-9]+/[0-9]+\\)")
+		val regex = Regex("\\([0-9]+/[0-9]+\\) (?:Armor|Equipment) Sets")
 		if (!regex.matches(event.screen.title.string)) return
 		if (!TConfig.wardrobeKeybinds) return
 
@@ -71,7 +71,7 @@ object WardrobeKeybinds {
 
 		val itemStack = invSlot.item
 		val isSelected = itemStack.item == Items.LIME_DYE
-		val isSelectable = itemStack.item == Items.PINK_DYE
+		val isSelectable = itemStack.item == Items.GRAY_DYE
 		if (!isSelectable && !isSelected) return
 		if (!TConfig.allowUnequipping && isSelected) return
 


### PR DESCRIPTION
fixes from more menus having title changes + unequipped slots being changed from pink dye to gray dye

<!--


Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->


## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [x] I have not used AI to author code
- [ ] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
