### PR TITLE
fix: make imageWidth and heightWidth mutable

### DIFF
--- a/src/main/java/moe/nea/firmament/mixins/accessor/AccessorHandledScreen.java
+++ b/src/main/java/moe/nea/firmament/mixins/accessor/AccessorHandledScreen.java
@@ -4,24 +4,27 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.world.inventory.Slot;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(AbstractContainerScreen.class)
 public interface AccessorHandledScreen {
     @Accessor("hoveredSlot")
     @Nullable
-	Slot getFocusedSlot_Firmament();
+    Slot getFocusedSlot_Firmament();
 
     @Accessor("imageWidth")
     int getBackgroundWidth_Firmament();
 
     @Accessor("imageWidth")
+    @Mutable
     void setBackgroundWidth_Firmament(int newBackgroundWidth);
 
     @Accessor("imageHeight")
     int getBackgroundHeight_Firmament();
 
     @Accessor("imageHeight")
+    @Mutable
     void setBackgroundHeight_Firmament(int newBackgroundHeight);
 
     @Accessor("leftPos")
@@ -35,5 +38,4 @@ public interface AccessorHandledScreen {
 
     @Accessor("topPos")
     void setY_Firmament(int newY);
-
 }

--- a/src/main/kotlin/features/inventory/storageoverlay/StorageOverlayCustom.kt
+++ b/src/main/kotlin/features/inventory/storageoverlay/StorageOverlayCustom.kt
@@ -48,8 +48,8 @@ class StorageOverlayCustom(
 		screen.y_Firmament = overview.measurements.y
 
 		//TODO: imageWidth and imageHeight has to be set in constructor as of 26.1
-		//screen.backgroundWidth_Firmament = overview.measurements.totalWidth
-		//screen.backgroundHeight_Firmament = overview.measurements.totalHeight
+		screen.backgroundWidth_Firmament = overview.measurements.totalWidth
+		screen.backgroundHeight_Firmament = overview.measurements.totalHeight
 	}
 
 	override fun isPointOverSlot(slot: Slot, xOffset: Int, yOffset: Int, pointX: Double, pointY: Double): Boolean {


### PR DESCRIPTION
<!--


Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->
Fixes #2344 
I have tested in dev env and in my regular game instance, there doesn't seem to be any issue.
REI displays as on 1.21.11 but Skyblocker buttons don't seem to display, I don't know why.
I have not tested with Firm buttons however.

## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [x] I have not used AI to author code
- [ ] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
