### PR TITLE
fix: set imageWidth/Height correctly

### DIFF
--- a/src/main/java/moe/nea/firmament/mixins/customgui/PatchHandledScreen.java
+++ b/src/main/java/moe/nea/firmament/mixins/customgui/PatchHandledScreen.java
@@ -33,12 +33,17 @@ public abstract class PatchHandledScreen<T extends AbstractContainerMenu> extend
 	@Shadow
 	protected int topPos;
 
+	@Unique
+	private int savedImageWidth;
+	@Unique
+	private int savedImageHeight;
+	@Unique
+	private boolean savedImage;
+
 	@Shadow
-	@Final
 	protected int imageWidth;
 
 	@Shadow
-	@Final
 	protected int imageHeight;
 
 	protected PatchHandledScreen() {
@@ -53,11 +58,16 @@ public abstract class PatchHandledScreen<T extends AbstractContainerMenu> extend
 
 	@Unique
 	public void fixSize() {
+		if (!savedImage) {
+			savedImageHeight = imageHeight;
+			savedImageWidth = imageWidth;
+			savedImage = true;
+		}
 		var override = getCustomGui_Firmament();
-		var width = override != null ? override.getBounds().getFirst().width : imageWidth; // TODO: first??
-		var height = override != null ? override.getBounds().getFirst().height : imageHeight;
-		this.leftPos = (this.width - width) / 2;
-		this.topPos = (this.height - height) / 2;
+		imageWidth = override != null ? override.getBounds().getFirst().width : savedImageWidth;
+		imageHeight = override != null ? override.getBounds().getFirst().height : savedImageHeight;
+		this.leftPos = (this.width - imageWidth) / 2;
+		this.topPos = (this.height - imageHeight) / 2;
 	}
 
 	@Inject(method = "init", at = @At("TAIL"))

--- a/src/main/resources/firmament.accesswidener
+++ b/src/main/resources/firmament.accesswidener
@@ -42,3 +42,6 @@ accessible field net/minecraft/client/renderer/rendertype/RenderSetup textures L
 accessible method net/minecraft/client/gui/GuiGraphicsExtractor innerBlit (Lcom/mojang/blaze3d/pipeline/RenderPipeline;Lnet/minecraft/resources/Identifier;IIIIFFFFI)V
 accessible class net/minecraft/client/resources/model/BlockStateModelLoader$LoadedBlockStateModelDispatcher
 accessible method net/minecraft/client/resources/model/BlockStateModelLoader$LoadedBlockStateModelDispatcher <init> (Ljava/lang/String;Lnet/minecraft/client/renderer/block/dispatch/BlockStateModelDispatcher;)V
+
+mutable field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen imageHeight I
+mutable field net/minecraft/client/gui/screens/inventory/AbstractContainerScreen imageWidth I


### PR DESCRIPTION
<!--


Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->

Should set the imageHeight/imageWidth stuff so that the storage overlay size is correct.


## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [x] I have not used AI to author code
- [ ] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
