### PR TITLE
fix(autoSprint): disable while a screen is open

### DIFF
--- a/src/main/kotlin/features/fixes/Fixes.kt
+++ b/src/main/kotlin/features/fixes/Fixes.kt
@@ -44,7 +44,8 @@ object Fixes {
 		// Having the sprint key pressed while in a GUI is normally harmless,
 		// as "sprinting" while not actually moving is completely invisible to
 		// the server. But there's a weird bug where it just causes the tooltips
-		// of animated dyed armor pieces to completely disappear.
+		// of animated dyed armor pieces to completely disappear. Likely
+		// something to do with the item being constantly updated.
 		if (MC.screen != null) return
 		val player = MC.player ?: return
 		if (player.isSprinting) return

--- a/src/main/kotlin/features/fixes/Fixes.kt
+++ b/src/main/kotlin/features/fixes/Fixes.kt
@@ -41,6 +41,11 @@ object Fixes {
 	) {
 		if (keyBinding !== Minecraft.getInstance().options.keySprint) return
 		if (!TConfig.autoSprint) return
+		// Having the sprint key pressed while in a GUI is normally harmless,
+		// as "sprinting" while not actually moving is completely invisible to
+		// the server. But there's a weird bug where it just causes the tooltips
+		// of animated dyed armor pieces to completely disappear.
+		if (MC.screen != null) return
 		val player = MC.player ?: return
 		if (player.isSprinting) return
 		if (!TConfig.autoSprintUnderWater && player.isInWater) return


### PR DESCRIPTION
<!--


Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->
This fixes a really weird obscure bug, the same thing happened with NoFrills. I added an explanatory comment for future readers.

https://discord.com/channels/1088154030628417616/1143270393793232906/1534391285530492959

## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [x] I have not used AI to author code
- [ ] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
