### PR TITLE
fix: support new enchanted book lore style with "Combinable in Anvil" header

### DIFF
--- a/src/main/java/moe/nea/firmament/repo/EnchantedBookCache.kt
+++ b/src/main/java/moe/nea/firmament/repo/EnchantedBookCache.kt
@@ -4,6 +4,7 @@ import io.github.moulberry.repo.IReloadable
 import io.github.moulberry.repo.NEURepository
 import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.removeColorCodes
+import moe.nea.firmament.util.skyblock.EnchantedBookLore
 import moe.nea.firmament.util.skyblockId
 
 class EnchantedBookCache : IReloadable {
@@ -11,6 +12,10 @@ class EnchantedBookCache : IReloadable {
 	override fun reload(repo: NEURepository) {
 		byName = repo.items.items.values
 			.filter { it.displayName.endsWith("Enchanted Book") }
-			.associate { it.lore.first().removeColorCodes() to it.skyblockId }
+			.mapNotNull { item ->
+				EnchantedBookLore.findEnchantmentName(item.lore)
+					?.let { it.removeColorCodes() to item.skyblockId }
+			}
+			.toMap()
 	}
 }

--- a/src/main/kotlin/features/inventory/MissingEnchantments.kt
+++ b/src/main/kotlin/features/inventory/MissingEnchantments.kt
@@ -11,6 +11,7 @@ import moe.nea.firmament.repo.RepoManager
 import moe.nea.firmament.util.data.Config
 import moe.nea.firmament.util.data.ManagedConfig
 import moe.nea.firmament.util.extraAttributes
+import moe.nea.firmament.util.skyblock.EnchantedBookLore
 import moe.nea.firmament.util.skyblock.ItemType
 import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.MC
@@ -37,7 +38,7 @@ object MissingEnchantments {
 	fun enchantIdToText(enchId: String, level: Int? = null): String? {
 		val skyblockId = SkyblockId("${enchId.uppercase()};${level ?: 1}")
 		val displayName = RepoManager.getNEUItem(skyblockId)
-			?.lore?.firstOrNull()
+			?.lore?.let(EnchantedBookLore::findEnchantmentName)
 
 		return if (level == null || level <= 1) {
 			displayName?.replace(Regex(" [IVX]+$"), "")

--- a/src/main/kotlin/repo/ItemNameLookup.kt
+++ b/src/main/kotlin/repo/ItemNameLookup.kt
@@ -7,6 +7,7 @@ import java.util.NavigableMap
 import java.util.TreeMap
 import moe.nea.firmament.util.SkyblockId
 import moe.nea.firmament.util.removeColorCodes
+import moe.nea.firmament.util.skyblock.EnchantedBookLore
 import moe.nea.firmament.util.skyblockId
 
 object ItemNameLookup : IReloadable {
@@ -35,7 +36,7 @@ object ItemNameLookup : IReloadable {
 		val names = mutableSetOf<String>()
 		names.add(item.displayName)
 		if (item.displayName.contains("Enchanted Book")) {
-			val enchantName = item.lore.firstOrNull()
+			val enchantName = EnchantedBookLore.findEnchantmentName(item.lore)
 			if (enchantName != null) {
 				names.add(enchantName)
 			}

--- a/src/main/kotlin/util/skyblock/EnchantedBookLore.kt
+++ b/src/main/kotlin/util/skyblock/EnchantedBookLore.kt
@@ -1,0 +1,30 @@
+package moe.nea.firmament.util.skyblock
+
+import moe.nea.firmament.util.removeColorCodes
+
+/**
+ * Utilities for reading the enchantment name out of the lore of an enchanted book.
+ *
+ * Newer books prefix their lore with a [COMBINABLE_IN_ANVIL] header and a blank line, older ones start with the
+ * enchantment name directly.
+ */
+object EnchantedBookLore {
+	const val COMBINABLE_IN_ANVIL = "Combinable in Anvil"
+
+	/**
+	 * Returns the (still formatted) lore line holding the enchantment name, or `null` if there is none.
+	 */
+	fun findEnchantmentName(lore: Sequence<String>): String? {
+		val iterator = lore.iterator()
+		if (!iterator.hasNext()) return null
+		val firstLine = iterator.next()
+		if (firstLine.removeColorCodes().trim() != COMBINABLE_IN_ANVIL) return firstLine
+		while (iterator.hasNext()) {
+			val line = iterator.next()
+			if (line.removeColorCodes().isNotBlank()) return line
+		}
+		return null
+	}
+
+	fun findEnchantmentName(lore: Iterable<String>): String? = findEnchantmentName(lore.asSequence())
+}

--- a/src/main/kotlin/util/skyblock/SBItemUtil.kt
+++ b/src/main/kotlin/util/skyblock/SBItemUtil.kt
@@ -11,7 +11,8 @@ object SBItemUtil {
 	fun DataComponentAccessor.getSearchName(): String {
 		val name = this.renderingName.unformattedString
 		if (name.contains("Enchanted Book")) {
-			val enchant = this.loreAccordingToNbt.firstOrNull()?.unformattedString
+			val enchant = EnchantedBookLore.findEnchantmentName(
+				this.loreAccordingToNbt.asSequence().map { it.unformattedString })
 			if (enchant != null) return enchant
 		}
 		if (name.startsWith("[Lvl")) {

--- a/src/test/kotlin/util/skyblock/EnchantedBookLoreTest.kt
+++ b/src/test/kotlin/util/skyblock/EnchantedBookLoreTest.kt
@@ -1,0 +1,91 @@
+package moe.nea.firmament.test.util.skyblock
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import moe.nea.firmament.util.skyblock.EnchantedBookLore
+
+class EnchantedBookLoreTest {
+	@Test
+	fun testOldLoreStyle() {
+		Assertions.assertEquals(
+			"§9Feather Falling VI",
+			EnchantedBookLore.findEnchantmentName(
+				listOf(
+					"§9Feather Falling VI",
+					"§7Increases how high you can fall",
+					"§7before taking fall damage by",
+					"§a6§7 and reduces fall damage by",
+					"§a30%§7.",
+					"",
+					"§9§lRARE",
+				)
+			)
+		)
+	}
+
+	@Test
+	fun testNewLoreStyle() {
+		Assertions.assertEquals(
+			"§9Feather Falling VI",
+			EnchantedBookLore.findEnchantmentName(
+				listOf(
+					"§8Combinable in Anvil",
+					"",
+					"§9Feather Falling VI",
+					"§7Increases how high you can fall",
+					"§7before taking fall damage by",
+					"§a6§7 and reduces fall damage by",
+					"§a30%§7.",
+					"",
+					"§9§lRARE",
+				)
+			)
+		)
+	}
+
+	@Test
+	fun testUltimateEnchantmentInNewLoreStyle() {
+		Assertions.assertEquals(
+			"§d§lUltimate Wise I",
+			EnchantedBookLore.findEnchantmentName(
+				listOf(
+					"§8Combinable in Anvil",
+					"",
+					"§d§lUltimate Wise I",
+					"§7Reduces the ability mana cost of",
+					"§7this item by §a10%§7.",
+					"",
+					"§f§lCOMMON",
+				)
+			)
+		)
+	}
+
+	@Test
+	fun testExtraBlankLinesAfterHeader() {
+		Assertions.assertEquals(
+			"§9Sharpness V",
+			EnchantedBookLore.findEnchantmentName(
+				listOf("§8Combinable in Anvil", "", "   ", "§9Sharpness V")
+			)
+		)
+	}
+
+	@Test
+	fun testHeaderWithoutColorCodes() {
+		Assertions.assertEquals(
+			"§9Sharpness V",
+			EnchantedBookLore.findEnchantmentName(listOf("Combinable in Anvil", "", "§9Sharpness V"))
+		)
+	}
+
+	@Test
+	fun testEmptyLore() {
+		Assertions.assertNull(EnchantedBookLore.findEnchantmentName(listOf<String>()))
+	}
+
+	@Test
+	fun testHeaderOnly() {
+		Assertions.assertNull(EnchantedBookLore.findEnchantmentName(listOf("§8Combinable in Anvil", "")))
+	}
+}

--- a/src/test/kotlin/util/skyblock/SBItemUtilTest.kt
+++ b/src/test/kotlin/util/skyblock/SBItemUtilTest.kt
@@ -1,0 +1,22 @@
+package moe.nea.firmament.test.util.skyblock
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import moe.nea.firmament.test.testutil.ItemResources
+import moe.nea.firmament.util.mc.RequiresComponents
+import moe.nea.firmament.util.skyblock.SBItemUtil.getSearchName
+
+class SBItemUtilTest {
+	@OptIn(RequiresComponents::class)
+	@TestFactory
+	fun searchNameOfEnchantedBooks() =
+		listOf(
+			"books/feather_falling" to "Feather Falling VI",
+			"books/feather_falling_combinable" to "Feather Falling VI",
+		).map { (name, searchName) ->
+			DynamicTest.dynamicTest("return $searchName for $name") {
+				Assertions.assertEquals(searchName, ItemResources.loadItem(name).getSearchName())
+			}
+		}
+}

--- a/src/test/resources/testdata/items/books/feather_falling_combinable.snbt
+++ b/src/test/resources/testdata/items/books/feather_falling_combinable.snbt
@@ -1,0 +1,42 @@
+{
+	source: {
+		dataVersion: 4189,
+	},
+	components: {
+		"minecraft:attribute_modifiers": {
+			modifiers: [
+			],
+			show_in_tooltip: 0b
+		},
+		"minecraft:custom_data": {
+			enchantments: {
+				feather_falling: 6
+			},
+			id: "ENCHANTED_BOOK",
+			timestamp: 1737123521091L,
+			uuid: "b8128489-9ed0-4a1a-94c0-d3279ffe45ac"
+		},
+		"minecraft:custom_name": '{"extra":[{"color":"blue","text":"Enchanted Book"}],"italic":false,"text":""}',
+		"minecraft:hide_additional_tooltip": {
+		},
+		"minecraft:lore": [
+			'{"extra":[{"color":"dark_gray","text":"Combinable in Anvil"}],"italic":false,"text":""}',
+			'{"italic":false,"text":""}',
+			'{"extra":[{"color":"blue","text":"Feather Falling VI"}],"italic":false,"text":""}',
+			'{"extra":[{"color":"gray","text":"Increases how high you can fall"}],"italic":false,"text":""}',
+			'{"extra":[{"color":"gray","text":"before taking fall damage by"}],"italic":false,"text":""}',
+			'{"extra":[{"color":"green","text":"6"},{"color":"gray","text":" and reduces fall damage by"}],"italic":false,"text":""}',
+			'{"extra":[{"color":"green","text":"30%"},{"color":"gray","text":"."}],"italic":false,"text":""}',
+			'{"italic":false,"text":""}',
+			'{"extra":[{"color":"gold","text":"Source:"}],"italic":false,"text":""}',
+			'{"extra":[{"color":"green","text":"VI-X: "},{"color":"gray","text":"Dungeon"}],"italic":false,"text":""}',
+			'{"italic":false,"text":""}',
+			'{"extra":[{"color":"gold","text":"Applied To:"}],"italic":false,"text":""}',
+			'{"extra":[{"color":"gray","text":"- "},{"color":"white","text":"Boots"}],"italic":false,"text":""}',
+			'{"italic":false,"text":""}',
+			'{"extra":[{"bold":true,"color":"blue","text":"RARE"}],"italic":false,"text":""}'
+		]
+	},
+	count: 1,
+	id: "minecraft:enchanted_book"
+}


### PR DESCRIPTION
<!--


Thank you for considering contributing to Firmament!

While i am grateful for every pull request i receive, i can be quite busy from time to time so reviewing your PR might take some time.
-->
Fixes features parsing all enchanted book names as "Combinable in Anvil" after a Hypixel lore change a few months ago that the NEU repo has also finally fully adopted.

Before this fix, it was something like "Missing Enchantments: Combinable in Anvil, Combinable in Anvil, Combinable in Anvil, Combinable in Anvil, Combinable in Anvil, Combinable in Anvil, Combinable in Anvil".

<img width="2880" height="1684" alt="2026-08-14_19 17 37" src="https://github.com/user-attachments/assets/83ad27e3-e986-41bf-82bd-51f287c9faa5" />


## Acknowledgements

By submitting this PR you acknowledge automatically per [platform rules](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license) that you license your changes under the license present in the files, as declared by the repository license, and in particular by the REUSE specification for your file.


Hypixel rules:

- [x] I am not aware of a Hypixel rule which my changes would violate.
<!--
You can find the rules at https://hypixel.net/rules
-->

AI use:

- [ ] I have not used AI to author code
- [x] I have used AI to author code and declared it as a coauthor using the `Co-Authored-By` commit trailer.
- [ ] I have used AI to author code, but not declared it in the commit trailer and would like a maintainer to do so for me. I have used AI_NAME_HERE.

<!--
For reference, here are the E-Mails of some known coding agents:

- Codex <codex@openai.com>
- Claude <noreply@anthropic.com>

-->
